### PR TITLE
Fixes an issue when the slurm job mem is reported as zero. 

### DIFF
--- a/reportseff/job.py
+++ b/reportseff/job.py
@@ -150,7 +150,10 @@ def parsemem(mem: str, nodes: int, cpus: int):
     multiple = mem[-2]
     alloc = mem[-1]
 
-    mem = float(mem[:-2]) * multiple_map[multiple]
+    if mem[-2:-1].isdigit():
+      mem=0.
+    else:
+      mem = float(mem[:-2]) * multiple_map[multiple]
 
     if alloc == 'n':
         return mem * nodes


### PR DESCRIPTION
The slurm job mem can be reported as zero when slurm jobs are submitted with
erroneous mem values, and defaults to 0(zero) in the slurmdb.
In this scenario, the memory is reported without a unit, and removing
the final two characters of the memory value (which strips the unit
chars), results in error.
Before stripping out the last two chars of the slurm mem value, first
check whether the last-but-one char is a digit.