### PR TITLE
run black + flake8 through 1st-party hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,15 +5,19 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: local
+
+-   repo: https://github.com/psf/black
+    rev: 21.9b0
     hooks:
     -   id: black
-        name: black
-        entry: poetry run black
-        language: system
-        types: [python]
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
     -   id: flake8
-        name: flake8
-        entry: poetry run flake8
-        language: system
-        types: [python]
+
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py37-plus]

--- a/src/reportseff/db_inquirer.py
+++ b/src/reportseff/db_inquirer.py
@@ -101,7 +101,7 @@ class SacctInquirer(BaseInquirer):
             stdout=subprocess.PIPE,
             encoding="utf8",
             check=True,
-            universal_newlines=True,
+            text=True,
             shell=False,
         )
         if cmd_result.returncode != 0:
@@ -147,7 +147,7 @@ class SacctInquirer(BaseInquirer):
             stdout=subprocess.PIPE,
             encoding="utf8",
             check=True,
-            universal_newlines=True,
+            text=True,
             shell=False,
         )
 


### PR DESCRIPTION
May I suggest running `black` and `flake8` through their own 1st-party hooks rather than through `poetry`? This avoids the need for contributors to install `poetry` and makes `pre-commit` itself the only dependency needed to run these hooks.

With the current setup, just cloning the repo and installing `pre-commit` into a `virtualenv`, `pre-commit run -av` results in

```sh
black....................................................................Failed
- hook id: black
- duration: 0s
- exit code: 1

Executable `poetry` not found
```

With this PR, you get

```sh
Check Yaml...............................................................Passed
- hook id: check-yaml
- duration: 0.09s
Fix End of Files.........................................................Passed
- hook id: end-of-file-fixer
- duration: 0.08s
Trim Trailing Whitespace.................................................Passed
- hook id: trailing-whitespace
- duration: 0.08s
black....................................................................Passed
- hook id: black
- duration: 0.87s

All done! ✨ 🍰 ✨
12 files left unchanged.

flake8...................................................................Passed
- hook id: flake8
- duration: 0.84s
pyupgrade................................................................Passed
- hook id: pyupgrade
- duration: 0.19s
```

I also took the liberty to add the excellent `pyupgrade` hook.