### PR TITLE
Fix output GPU

### DIFF
--- a/src/reportseff/job.py
+++ b/src/reportseff/job.py
@@ -232,8 +232,8 @@ class Job:
         self.other_entries["State"] = self.state
         self.other_entries["TimeEff"] = self.time_eff
         self.other_entries["CPUEff"] = self.cpu if self.cpu else "---"
-        self.other_entries["GPUEff"] = self.gpu if self.gpu else "---"
-        self.other_entries["GPUMem"] = self.gpu_mem if self.gpu_mem else "---"
+        self.other_entries["GPUEff"] = self.gpu if self.gpu is not None else "---"
+        self.other_entries["GPUMem"] = self.gpu_mem if self.gpu_mem is not None else "---"
 
     def name(self) -> str:
         """The name of the job.
@@ -276,7 +276,7 @@ class Job:
             not change in nodes/gpus it will yield an empty string
         """
         yield self.get_entry(key)
-        if len(self.comment_data) > 1 or (gpu and self.gpu):
+        if len(self.comment_data) > 1 or (gpu and self.gpu is not None):
             for node, data in self.comment_data.items():
                 # get node-level data
                 if key == "JobID":
@@ -287,7 +287,7 @@ class Job:
                         to_yield if isinstance(to_yield, str) else round(to_yield, 1)
                     )
                     yield to_yield
-                if gpu and self.gpu:  # has gpus to report
+                if gpu and self.gpu is not None:  # has gpus to report
                     for gpu_name, gpu_data in data["gpus"].items():
                         if key == "JobID":
                             yield f"    {gpu_name}"

--- a/src/reportseff/job.py
+++ b/src/reportseff/job.py
@@ -233,7 +233,10 @@ class Job:
         self.other_entries["TimeEff"] = self.time_eff
         self.other_entries["CPUEff"] = self.cpu if self.cpu else "---"
         self.other_entries["GPUEff"] = self.gpu if self.gpu is not None else "---"
-        self.other_entries["GPUMem"] = self.gpu_mem if self.gpu_mem is not None else "---"
+        if self.gpu_mem is not None:
+            self.other_entries["GPUMem"] = self.gpu_mem
+        else:
+            self.other_entries["GPUMem"] = "---"
 
     def name(self) -> str:
         """The name of the job.


### PR DESCRIPTION
When an user ask a GPU but never used it. It can be interesting to see a more explicit value than "---"
In this example with my code, an user ask 1 GPU per node for 2 nodes. 
```
(venv) [braffest@maestro-3002 ~]$ reportseff -g 649436
JobID               State       Elapsed  TimeEff   CPUEff   MemEff   GPUEff   GPUMem 
649436            COMPLETED    00:00:13   0.0%      ---     11.7%     0.0%     0.0%  
  maestro-3000                                      0.0%    11.7%     0.0%     0.0%  
    0                                                                  0%      0.0%  

```
But currently, we can think, there is no GPU allocated to this jobs.
```
(venv) [braffest@maestro-3002 ~]$ reportseff -g 649436
JobID       State       Elapsed  TimeEff   CPUEff   MemEff   GPUEff   GPUMem 
649436    COMPLETED    00:00:13   0.0%      ---     11.7%     ---      ---
```

