### PR TITLE
feat: add energy as a valid column

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reportseff"
-version = "2.4.3"
+version = "2.5.0"
 description= "Tablular seff output"
 authors = ["Troy Comi <troycomi@gmail.com>"]
 license = "MIT"

--- a/src/reportseff/console.py
+++ b/src/reportseff/console.py
@@ -29,8 +29,8 @@ from .parameters import ReportseffParameters
     "format_str",
     default="JobID%>,State,Elapsed%>,TimeEff,CPUEff,MemEff",
     help="Comma-separated list of columns to include. Options "
-    "are any valid sacct input along with CPUEff, MemEff, and "
-    "TimeEff.  In systems with jobstat caching, GPU usage can be "
+    "are any valid sacct input along with CPUEff, MemEff, Energy, "
+    "and TimeEff.  In systems with jobstat caching, GPU usage can be "
     "added with GPUEff, GPUMem or GPU (for both). "
     "A width and alignment may optionally be provided "
     'after "%", e.g. JobID%>15 aligns job id right with max '

--- a/src/reportseff/output_renderer.py
+++ b/src/reportseff/output_renderer.py
@@ -50,6 +50,7 @@ class OutputRenderer:
             "GPU": [],
             "GPUMem": [],
             "GPUEff": [],
+            "Energy": ["TRESUsageOutAve"],
         }
 
         self.parsable = parsable


### PR DESCRIPTION
Added option to report energy usage of jobs.
Taken from the tres entry, for multi-node jobs take the max value.
