### PR TITLE
feat: add ability to forward extra args to sacct

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 name: Coverage
-on: push
+on: [push, pull_request]
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reportseff"
-version = "2.5.0"
+version = "2.6.0"
 description= "Tablular seff output"
 authors = ["Troy Comi <troycomi@gmail.com>"]
 license = "MIT"

--- a/src/reportseff/console.py
+++ b/src/reportseff/console.py
@@ -57,7 +57,7 @@ from .parameters import ReportseffParameters
     help="Only include jobs with the specified partition",
 )
 @click.option(
-    "--extra_args",
+    "--extra-args",
     default="",
     help="Extra arguments to forward to sacct",
 )

--- a/src/reportseff/console.py
+++ b/src/reportseff/console.py
@@ -57,6 +57,11 @@ from .parameters import ReportseffParameters
     help="Only include jobs with the specified partition",
 )
 @click.option(
+    "--extra_args",
+    default="",
+    help="Extra arguments to forward to sacct",
+)
+@click.option(
     "-s", "--state", default="", help="Only include jobs with the specified states"
 )
 @click.option(
@@ -139,6 +144,9 @@ def get_jobs(args: ReportseffParameters) -> Tuple[str, int]:
     inquirer.set_until(args.until)
 
     inquirer.set_partition(args.partition)
+
+    inquirer.set_extra_args(args.extra_args)
+
     add_jobs = False
 
     try:

--- a/src/reportseff/console.py
+++ b/src/reportseff/console.py
@@ -70,7 +70,7 @@ from .parameters import ReportseffParameters
 @click.option(
     "--since",
     default="",
-    help="Only include jobs before this time. Can be valid sacct "
+    help="Only include jobs after this time. Can be valid sacct "
     "or as a comma separated list of time deltas, e.g. d=2,h=1 "
     "means 2 days, 1 hour before current time. Weeks, days, "
     "hours, and minutes can use case-insensitive abbreviations. "

--- a/src/reportseff/db_inquirer.py
+++ b/src/reportseff/db_inquirer.py
@@ -2,9 +2,8 @@
 from abc import ABC, abstractmethod
 import datetime
 import re
-import subprocess
 import shlex
-
+import subprocess
 from typing import Callable, Dict, List, Optional, Set
 
 import click
@@ -77,7 +76,7 @@ class BaseInquirer(ABC):
 
     @abstractmethod
     def set_extra_args(self, extra_args: str) -> None:
-        """Set extra arguments to be forwarded to sacct
+        """Set extra arguments to be forwarded to sacct.
 
         Args:
             extra_args: list of arguments
@@ -202,14 +201,14 @@ class SacctInquirer(BaseInquirer):
             if not self.since:
                 start_date = datetime.date.today() - datetime.timedelta(days=7)
                 self.since = start_date.strftime("%m%d%y")  # MMDDYY
-            args += [f"--user={self.user}", f"--starttime={self.since}"]
+            args += [f"--user={self.user}"]
         elif self.query_all_users:
-            args += ["--allusers", f"--starttime={self.since}"]
+            args += ["--allusers"]
         else:
             args += ["--jobs=" + ",".join(jobs)]
-            if self.since:
-                args += [f"--starttime={self.since}"]
 
+        if self.since:
+            args += [f"--starttime={self.since}"]
         if self.partition:
             args += [f"--partition={self.partition}"]
         if self.until:
@@ -288,7 +287,7 @@ class SacctInquirer(BaseInquirer):
         self.partition = partition
 
     def set_extra_args(self, extra_args: str) -> None:
-        """Set extra arguments to be forwarded to sacct
+        """Set extra arguments to be forwarded to sacct.
 
         Args:
             extra_args: list of arguments

--- a/src/reportseff/db_inquirer.py
+++ b/src/reportseff/db_inquirer.py
@@ -74,6 +74,14 @@ class BaseInquirer(ABC):
         """
 
     @abstractmethod
+    def set_extra_args(self, extra_args: str) -> None:
+        """Set extra arguments to be forwarded to sacct
+
+        Args:
+            extra_args: list of arguments
+        """
+
+    @abstractmethod
     def all_users(self) -> None:
         """Ignore provided jobs, query for all users."""
 
@@ -152,6 +160,7 @@ class SacctInquirer(BaseInquirer):
         self.until: Optional[str] = None
         self.query_all_users: bool = False
         self.partition: Optional[str] = None
+        self.extra_args: Optional[str] = None
 
     def get_valid_formats(self) -> List[str]:
         """Get the valid formatting options supported by the inquirer.
@@ -203,6 +212,8 @@ class SacctInquirer(BaseInquirer):
             args += [f"--partition={self.partition}"]
         if self.until:
             args += [f"--endtime={self.until}"]
+        if self.extra_args:
+            args += [f"{self.extra_args}"]
         return args
 
     def get_db_output(
@@ -273,6 +284,14 @@ class SacctInquirer(BaseInquirer):
             partition: partition name
         """
         self.partition = partition
+
+    def set_extra_args(self, extra_args: str) -> None:
+        """Set extra arguments to be forwarded to sacct
+
+        Args:
+            extra_args: list of arguments
+        """
+        self.extra_args = extra_args
 
     def all_users(self) -> None:
         """Query for all users if `since` is set."""

--- a/src/reportseff/db_inquirer.py
+++ b/src/reportseff/db_inquirer.py
@@ -3,6 +3,8 @@ from abc import ABC, abstractmethod
 import datetime
 import re
 import subprocess
+import shlex
+
 from typing import Callable, Dict, List, Optional, Set
 
 import click
@@ -213,7 +215,7 @@ class SacctInquirer(BaseInquirer):
         if self.until:
             args += [f"--endtime={self.until}"]
         if self.extra_args:
-            args += [f"{self.extra_args}"]
+            args += shlex.split(self.extra_args)
         return args
 
     def get_db_output(

--- a/src/reportseff/parameters.py
+++ b/src/reportseff/parameters.py
@@ -22,6 +22,7 @@ class ReportseffParameters:
     state: str = ""
     user: str = ""
     partition: str = ""
+    extra_args: str = ""
 
     def __init__(
         self,
@@ -39,6 +40,7 @@ class ReportseffParameters:
         state: str = "",
         user: str = "",
         partition: str = "",
+        extra_args: str = "",
     ) -> None:
         """Create a new parameter object.
 
@@ -57,6 +59,7 @@ class ReportseffParameters:
             state: stats to display
             user: the user to report for
             partition: the partition to report for
+            extra_args: extra arguments to forward to sacct
         """
         self.color = color
         self.debug = debug
@@ -72,6 +75,7 @@ class ReportseffParameters:
         self.state = state
         self.user = user
         self.partition = partition
+        self.extra_args = extra_args
 
         if self.format_str.startswith("+"):
             self.format_str = (

--- a/tests/test_db_inquirer.py
+++ b/tests/test_db_inquirer.py
@@ -713,3 +713,17 @@ def test_partition_timelimit_issue_11(sacct, mocker):
         "mainqueue": "UNLIMITED",
         "mainqueue2": "10-00:00:00",
     }
+
+
+def test_extra_args_setting(sacct):
+    """Setting extra args are properly handled."""
+    sacct.set_extra_args('-D --units M --nodelist "node1 node2"')
+    assert sacct.extra_args == '-D --units M --nodelist "node1 node2"'
+    assert sacct.set_sacct_args(["123"]) == [
+        "--jobs=123",
+        "-D",
+        "--units",
+        "M",
+        "--nodelist",
+        "node1 node2",
+    ]

--- a/tests/test_reportseff.py
+++ b/tests/test_reportseff.py
@@ -1,9 +1,9 @@
 """Test cli usage."""
+import shlex
 import subprocess
 
 from click.testing import CliRunner
 import pytest
-import shlex
 
 from reportseff import console
 from reportseff.db_inquirer import SacctInquirer
@@ -1013,11 +1013,15 @@ def test_energy_reporting(mocker, mock_inquirer):
     ]
     assert len(output) == 5
 
+
 def test_extra_args(mocker, mock_inquirer):
     """Can add extra arguments for sacct."""
     mocker.patch("reportseff.console.which", return_value=True)
     runner = CliRunner()
-    mock_jobs = mocker.patch("reportseff.console.get_jobs", return_value=("Testing", 1))
-    result = runner.invoke(console.main, shlex.split("--no-color --extra-args='-D --units M --nodelist=node1,node2'"))
+    mocker.patch("reportseff.console.get_jobs", return_value=("Testing", 1))
+    result = runner.invoke(
+        console.main,
+        shlex.split("--no-color --extra-args='-D --units M --nodelist=node1,node2'"),
+    )
 
     assert result.exit_code == 0

--- a/tests/test_reportseff.py
+++ b/tests/test_reportseff.py
@@ -3,6 +3,7 @@ import subprocess
 
 from click.testing import CliRunner
 import pytest
+import shlex
 
 from reportseff import console
 from reportseff.db_inquirer import SacctInquirer
@@ -1011,3 +1012,12 @@ def test_energy_reporting(mocker, mock_inquirer):
         "27",
     ]
     assert len(output) == 5
+
+def test_extra_args(mocker, mock_inquirer):
+    """Can add extra arguments for sacct."""
+    mocker.patch("reportseff.console.which", return_value=True)
+    runner = CliRunner()
+    mock_jobs = mocker.patch("reportseff.console.get_jobs", return_value=("Testing", 1))
+    result = runner.invoke(console.main, shlex.split("--no-color --extra-args='-D --units M --nodelist=node1,node2'"))
+
+    assert result.exit_code == 0


### PR DESCRIPTION
The simplest approach I could think of. Not sure if you had something different in mind.

Error messages in case of bad args seem reasonable:

```bash
$ reportseff --extra_args="--blah"
sacct: unrecognized option '--blah'
Error running sacct!
None
```

Closes #23  