### PR TITLE
fix: properly handle pipes in job names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reportseff"
-version = "2.7.4"
+version = "2.7.5"
 description= "Tablular seff output"
 authors = ["Troy Comi <troycomi@gmail.com>"]
 license = "MIT"

--- a/src/reportseff/db_inquirer.py
+++ b/src/reportseff/db_inquirer.py
@@ -153,7 +153,7 @@ class SacctInquirer(BaseInquirer):
 
     def __init__(self) -> None:
         """Initialize a new inquirer."""
-        self.default_args = "sacct -P -n".split()
+        self.default_args = "sacct -P -n --delimiter=^|^".split()
         self.user: Optional[str] = None
         self.state: Optional[Set] = None
         self.not_state: Optional[Set] = None
@@ -258,7 +258,8 @@ class SacctInquirer(BaseInquirer):
         if debug_cmd is not None:
             debug_cmd("\n".join(lines))
 
-        result = [dict(zip(columns, line.split("|"))) for line in lines if line]
+        sacct_split = re.compile(r"\^\|\^")
+        result = [dict(zip(columns, sacct_split.split(line))) for line in lines if line]
 
         if self.state:
             # split to get first word in entries like "CANCELLED BY X"

--- a/tests/test_db_inquirer.py
+++ b/tests/test_db_inquirer.py
@@ -15,7 +15,7 @@ def sacct():
 
 def test_sacct_init(sacct):
     """Check default options on new object."""
-    assert sacct.default_args == ["sacct", "-P", "-n"]
+    assert sacct.default_args == ["sacct", "-P", "-n", "--delimiter=^|^"]
     assert sacct.user is None
 
 
@@ -186,7 +186,7 @@ def test_sacct_get_db_output(sacct, mocker):
 
     mock_sacct = mocker.MagicMock()
     mock_sacct.returncode = 0
-    mock_sacct.stdout = "c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n"
+    mock_sacct.stdout = "c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n"
     mock_sub = mocker.patch(
         "reportseff.db_inquirer.subprocess.run", return_value=mock_sacct
     )
@@ -197,7 +197,7 @@ def test_sacct_get_db_output(sacct, mocker):
         {"c1": "c1j3", "c2": "c2j3"},
     ]
     mock_sub.assert_called_once_with(
-        args="sacct -P -n --format=c1,c2 --jobs=j1,j2,j3".split(),
+        args="sacct -P -n --delimiter=^|^ --format=c1,c2 --jobs=j1,j2,j3".split(),
         stdout=mocker.ANY,
         encoding=mocker.ANY,
         check=mocker.ANY,
@@ -207,7 +207,7 @@ def test_sacct_get_db_output(sacct, mocker):
 
     debug = []
     sacct.get_db_output("c1 c2".split(), "j1 j2 j3".split(), debug.append)
-    assert debug[0] == ("c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n")
+    assert debug[0] == ("c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n")
 
 
 def test_sacct_get_db_output_no_newline(sacct, mocker):
@@ -215,8 +215,8 @@ def test_sacct_get_db_output_no_newline(sacct, mocker):
     mock_sacct = mocker.MagicMock()
     mock_sacct.returncode = 0
     mock_sacct.stdout = (
-        "16|00:00:00|23000233|23000233||1|4000Mc|CANCELLED by 129319|"
-        "6-00:00:00|00:00:00"
+        "16^|^00:00:00^|^23000233^|^23000233^|^^|^1^|^4000Mc^|^CANCELLED by 129319^|^"
+        "6-00:00:00^|^00:00:00"
     )
     mock_sub = mocker.patch(
         "reportseff.db_inquirer.subprocess.run", return_value=mock_sacct
@@ -255,8 +255,8 @@ def test_sacct_get_db_output_no_newline(sacct, mocker):
     mock_sub.assert_called_once()
 
     assert debug[0] == (
-        "16|00:00:00|23000233|23000233||1|4000Mc|CANCELLED by 129319|"
-        "6-00:00:00|00:00:00"
+        "16^|^00:00:00^|^23000233^|^23000233^|^^|^1^|^4000Mc^|^CANCELLED by 129319^|^"
+        "6-00:00:00^|^00:00:00"
     )
 
 
@@ -282,7 +282,7 @@ def test_sacct_get_db_output_user(sacct, mocker):
 
     mock_sacct = mocker.MagicMock()
     mock_sacct.returncode = 0
-    mock_sacct.stdout = "c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n"
+    mock_sacct.stdout = "c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n"
     mock_sub = mocker.patch(
         "reportseff.db_inquirer.subprocess.run", return_value=mock_sacct
     )
@@ -294,7 +294,9 @@ def test_sacct_get_db_output_user(sacct, mocker):
         {"c1": "c1j3", "c2": "c2j3"},
     ]
     mock_sub.assert_called_once_with(
-        args=("sacct -P -n --format=c1,c2 --user=user --starttime=011318").split(),
+        args=(
+            "sacct -P -n --delimiter=^|^ --format=c1,c2 --user=user --starttime=011318"
+        ).split(),
         stdout=mocker.ANY,
         encoding=mocker.ANY,
         check=mocker.ANY,
@@ -304,7 +306,7 @@ def test_sacct_get_db_output_user(sacct, mocker):
 
     debug = []
     sacct.get_db_output("c1 c2".split(), "j1 j2 j3".split(), debug.append)
-    assert debug[0] == ("c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n")
+    assert debug[0] == ("c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n")
 
 
 def test_sacct_set_partition(sacct):
@@ -317,7 +319,7 @@ def test_sacct_get_db_output_partition(sacct, mocker):
     """Subprocess call is affected by partition argument."""
     mock_sacct = mocker.MagicMock()
     mock_sacct.returncode = 0
-    mock_sacct.stdout = "c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n"
+    mock_sacct.stdout = "c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n"
     mock_sub = mocker.patch(
         "reportseff.db_inquirer.subprocess.run", return_value=mock_sacct
     )
@@ -329,7 +331,9 @@ def test_sacct_get_db_output_partition(sacct, mocker):
         {"c1": "c1j3", "c2": "c2j3"},
     ]
     mock_sub.assert_called_once_with(
-        args=("sacct -P -n --format=c1,c2 --jobs= --partition=partition").split(),
+        args=(
+            "sacct -P -n --delimiter=^|^ --format=c1,c2 --jobs= --partition=partition"
+        ).split(),
         stdout=mocker.ANY,
         encoding=mocker.ANY,
         check=mocker.ANY,
@@ -339,14 +343,14 @@ def test_sacct_get_db_output_partition(sacct, mocker):
 
     debug = []
     sacct.get_db_output("c1 c2".split(), "j1 j2 j3".split(), debug.append)
-    assert debug[0] == ("c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n")
+    assert debug[0] == ("c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n")
 
 
 def test_sacct_get_db_output_since(sacct, mocker):
     """Subprocess call is affected by since argument."""
     mock_sacct = mocker.MagicMock()
     mock_sacct.returncode = 0
-    mock_sacct.stdout = "c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n"
+    mock_sacct.stdout = "c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n"
     mock_sub = mocker.patch(
         "reportseff.db_inquirer.subprocess.run", return_value=mock_sacct
     )
@@ -358,7 +362,9 @@ def test_sacct_get_db_output_since(sacct, mocker):
         {"c1": "c1j3", "c2": "c2j3"},
     ]
     mock_sub.assert_called_once_with(
-        args=("sacct -P -n --format=c1,c2 --jobs= --starttime=time ").split(),
+        args=(
+            "sacct -P -n --delimiter=^|^ --format=c1,c2 --jobs= --starttime=time "
+        ).split(),
         stdout=mocker.ANY,
         encoding=mocker.ANY,
         check=mocker.ANY,
@@ -368,14 +374,14 @@ def test_sacct_get_db_output_since(sacct, mocker):
 
     debug = []
     sacct.get_db_output("c1 c2".split(), "j1 j2 j3".split(), debug.append)
-    assert debug[0] == ("c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n")
+    assert debug[0] == ("c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n")
 
 
 def test_sacct_get_db_output_until(sacct, mocker):
     """Subprocess call is affected by until argument."""
     mock_sacct = mocker.MagicMock()
     mock_sacct.returncode = 0
-    mock_sacct.stdout = "c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n"
+    mock_sacct.stdout = "c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n"
     mock_sub = mocker.patch(
         "reportseff.db_inquirer.subprocess.run", return_value=mock_sacct
     )
@@ -387,7 +393,9 @@ def test_sacct_get_db_output_until(sacct, mocker):
         {"c1": "c1j3", "c2": "c2j3"},
     ]
     mock_sub.assert_called_once_with(
-        args=("sacct -P -n --format=c1,c2 --jobs= --endtime=time ").split(),
+        args=(
+            "sacct -P -n --delimiter=^|^ --format=c1,c2 --jobs= --endtime=time "
+        ).split(),
         stdout=mocker.ANY,
         encoding=mocker.ANY,
         check=mocker.ANY,
@@ -397,7 +405,7 @@ def test_sacct_get_db_output_until(sacct, mocker):
 
     debug = []
     sacct.get_db_output("c1 c2".split(), "j1 j2 j3".split(), debug.append)
-    assert debug[0] == ("c1j1|c2j1\nc1j2|c2j2\nc1j3|c2j3\n")
+    assert debug[0] == ("c1j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n")
 
 
 def test_sacct_set_state(sacct, capsys):
@@ -610,7 +618,9 @@ def test_sacct_get_db_output_user_state(sacct, mocker):
 
     mock_sacct = mocker.MagicMock()
     mock_sacct.returncode = 0
-    mock_sacct.stdout = "c1j1|c2j1|RUNNING\nc1j2|c2j2|RUNNING\nc1j3|c2j3|COMPLETED\n"
+    mock_sacct.stdout = (
+        "c1j1^|^c2j1^|^RUNNING\nc1j2^|^c2j2^|^RUNNING\nc1j3^|^c2j3^|^COMPLETED\n"
+    )
     mock_sub = mocker.patch(
         "reportseff.db_inquirer.subprocess.run", return_value=mock_sacct
     )
@@ -623,7 +633,8 @@ def test_sacct_get_db_output_user_state(sacct, mocker):
     ]
     mock_sub.assert_called_once_with(
         args=(
-            "sacct -P -n --format=c1,c2,State --user=user --starttime=011318"
+            "sacct -P -n --delimiter=^|^ --format=c1,c2,State"
+            " --user=user --starttime=011318"
         ).split(),
         stdout=mocker.ANY,
         encoding=mocker.ANY,
@@ -635,7 +646,9 @@ def test_sacct_get_db_output_user_state(sacct, mocker):
     # debug is not affected by state
     debug = []
     sacct.get_db_output("c1 c2 State".split(), "j1 j2 j3".split(), debug.append)
-    assert debug[0] == ("c1j1|c2j1|RUNNING\nc1j2|c2j2|RUNNING\nc1j3|c2j3|COMPLETED\n")
+    assert debug[0] == (
+        "c1j1^|^c2j1^|^RUNNING\nc1j2^|^c2j2^|^RUNNING\nc1j3^|^c2j3^|^COMPLETED\n"
+    )
 
 
 def test_partition_timelimit_failure(sacct, mocker):
@@ -727,3 +740,36 @@ def test_extra_args_setting(sacct):
         "--nodelist",
         "node1 node2",
     ]
+
+
+def test_sacct_get_db_output_issue_30(sacct, mocker):
+    """Handle cases where jobname has a pipe."""
+    mocker.patch(
+        "reportseff.db_inquirer.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, "test"),
+    )
+
+    mock_sacct = mocker.MagicMock()
+    mock_sacct.returncode = 0
+    mock_sacct.stdout = "c1 | j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n"
+    mock_sub = mocker.patch(
+        "reportseff.db_inquirer.subprocess.run", return_value=mock_sacct
+    )
+    result = sacct.get_db_output("c1 c2".split(), "j1 j2 j3".split())
+    assert result == [
+        {"c1": "c1 | j1", "c2": "c2j1"},
+        {"c1": "c1j2", "c2": "c2j2"},
+        {"c1": "c1j3", "c2": "c2j3"},
+    ]
+    mock_sub.assert_called_once_with(
+        args="sacct -P -n --delimiter=^|^ --format=c1,c2 --jobs=j1,j2,j3".split(),
+        stdout=mocker.ANY,
+        encoding=mocker.ANY,
+        check=mocker.ANY,
+        shell=False,
+        universal_newlines=True,
+    )
+
+    debug = []
+    sacct.get_db_output("c1 c2".split(), "j1 j2 j3".split(), debug.append)
+    assert debug[0] == ("c1 | j1^|^c2j1\nc1j2^|^c2j2\nc1j3^|^c2j3\n")

--- a/tests/test_reportseff.py
+++ b/tests/test_reportseff.py
@@ -37,12 +37,12 @@ def test_directory_input(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|03:00:00|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED||01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED||00:00:00\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^03:00:00^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
 
@@ -75,12 +75,12 @@ def test_directory_input_exception(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "24418435|24418435|COMPLETED|1|"
-        "01:27:29|01:27:42|03:00:00|1Gn||1|\n"
-        "24418435.batch|24418435.batch|COMPLETED|1|"
-        "01:27:29|01:27:42||1Gn|499092K|1|1\n"
-        "24418435.extern|24418435.extern|COMPLETED|1|"
-        "00:00:00|01:27:42||1Gn|1376K|1|1\n"
+        "24418435^|^24418435^|^COMPLETED^|^1^|^"
+        "01:27:29^|^01:27:42^|^03:00:00^|^1Gn^|^^|^1^|^\n"
+        "24418435.batch^|^24418435.batch^|^COMPLETED^|^1^|^"
+        "01:27:29^|^01:27:42^|^^|^1Gn^|^499092K^|^1^|^1\n"
+        "24418435.extern^|^24418435.extern^|^COMPLETED^|^1^|^"
+        "00:00:00^|^01:27:42^|^^|^1Gn^|^1376K^|^1^|^1\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
 
@@ -101,8 +101,8 @@ def test_debug_option(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|16|00:00:00|23000233|23000233||1|4000Mc|"
-        "CANCELLED by 129319|6-00:00:00|00:00:00\n"
+        "^|^16^|^00:00:00^|^23000233^|^23000233^|^^|^1^|^4000Mc^|^"
+        "CANCELLED by 129319^|^6-00:00:00^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -114,8 +114,8 @@ def test_debug_option(mocker, mock_inquirer):
     # remove header
     output = result.output.split("\n")
     assert output[0] == (
-        "|16|00:00:00|23000233|23000233||1|4000Mc|"
-        "CANCELLED by 129319|6-00:00:00|00:00:00"
+        "^|^16^|^00:00:00^|^23000233^|^23000233^|^^|^1^|^4000Mc^|^"
+        "CANCELLED by 129319^|^6-00:00:00^|^00:00:00"
     )
     assert output[3].split() == [
         "23000233",
@@ -134,8 +134,8 @@ def test_process_failure(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|16|00:00:00|23000233|23000233||1|4000Mc|"
-        "CANCELLED by 129319|6-00:00:00|00:00:00\n"
+        "^|^16^|^00:00:00^|^23000233^|^23000233^|^^|^1^|^4000Mc^|^"
+        "CANCELLED by 129319^|^6-00:00:00^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     mocker.patch.object(
@@ -165,8 +165,8 @@ def test_short_output(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|23000233|23000233|CANCELLED by 129319|16|"
-        "00:00:00|00:00:00|6-00:00:00|4000Mc||1|\n"
+        "^|^23000233^|^23000233^|^CANCELLED by 129319^|^16^|^"
+        "00:00:00^|^00:00:00^|^6-00:00:00^|^4000Mc^|^^|^1^|^\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     mocker.patch("reportseff.console.len", return_value=20)
@@ -186,7 +186,8 @@ def test_long_output(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|16|00:00:00|23000233|23000233||1|4000Mc|CANCELLED by 129319|00:00:00\n"
+        "^|^16^|^00:00:00^|^23000233^|^23000233"
+        "^|^^|^1^|^4000Mc^|^CANCELLED by 129319^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     mocker.patch("reportseff.console.len", return_value=21)
@@ -205,12 +206,12 @@ def test_simple_job(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -231,16 +232,17 @@ def test_simple_user(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|COMPLETED|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|COMPLETED|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern^|^1548K^|^1^|^4000Mc^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0^|^62328K"
+        "^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -262,16 +264,17 @@ def test_simple_partition(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|COMPLETED|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|COMPLETED|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern^|^1548K^|^1^|^4000Mc^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0"
+        "^|^62328K^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -314,16 +317,17 @@ def test_since(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|COMPLETED|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|COMPLETED|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern^|^1548K^|^1^|^4000Mc^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0^|^62328K"
+        "^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -348,16 +352,17 @@ def test_since_all_users(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|COMPLETED|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|COMPLETED|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern^|^1548K^|^1^|^4000Mc^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0^|^62328K"
+        "^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
     )
     mock_sub = mocker.patch(
         "reportseff.db_inquirer.subprocess.run", return_value=sub_result
@@ -378,7 +383,7 @@ def test_since_all_users(mocker, mock_inquirer):
 
     mock_sub.assert_called_once_with(
         args=(
-            "sacct -P -n "
+            "sacct -P -n --delimiter=^|^ "
             "--format=AdminComment,AllocCPUS,Elapsed,JobID,JobIDRaw,"
             "MaxRSS,NNodes,REQMEM,State,TotalCPU "
             "--allusers "  # all users is added since no jobs/files were specified
@@ -399,16 +404,17 @@ def test_since_all_users_partition(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|COMPLETED|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|COMPLETED|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern^|^1548K^|^1^|^4000Mc^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0^|^62328K"
+        "^|^1^|^4000Mc^|^COMPLETED^|^19:28:36\n"
     )
     mock_sub = mocker.patch(
         "reportseff.db_inquirer.subprocess.run", return_value=sub_result
@@ -429,7 +435,7 @@ def test_since_all_users_partition(mocker, mock_inquirer):
 
     mock_sub.assert_called_once_with(
         args=(
-            "sacct -P -n "
+            "sacct -P -n --delimiter=^|^ "
             "--format=AdminComment,AllocCPUS,Elapsed,JobID,JobIDRaw,"
             "MaxRSS,NNodes,REQMEM,State,TotalCPU "
             "--allusers "  # all users is added since no jobs/files were specified
@@ -451,16 +457,17 @@ def test_parsable(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|RUNNING|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "RUNNING|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|RUNNING|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern^|^1548K^|^1^|^4000Mc^|^"
+        "RUNNING^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0^|^62328K"
+        "^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -474,7 +481,7 @@ def test_parsable(mocker, mock_inquirer):
     assert result.exit_code == 0
     # remove header
     output = result.output.split("\n")[1:]
-    # no color/bold codes and | delimited
+    # no color/bold codes and ^|^ delimited
     assert output[0].split("|") == ["24418435", "COMPLETED", "01:27:42", "99.8", "47.6"]
     # other is suppressed by state filter
     assert output[1].split("|") == ["25569410", "RUNNING", "21:14:48", "---", "---"]
@@ -487,16 +494,17 @@ def test_simple_state(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|RUNNING|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "RUNNING|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|RUNNING|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern^|^1548K^|^1^|^4000Mc^|^"
+        "RUNNING^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0^|^62328K"
+        "^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -522,16 +530,17 @@ def test_simple_not_state(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|RUNNING|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "RUNNING|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|RUNNING|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern^|^1548K^|^1^|^4000Mc^|^"
+        "RUNNING^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0^|^62328K"
+        "^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -557,16 +566,17 @@ def test_invalid_not_state(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|RUNNING|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "RUNNING|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|RUNNING|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern^|^1548K^|^1^|^4000Mc^|^"
+        "RUNNING^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0^|^62328K"
+        "^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -595,16 +605,17 @@ def test_no_state(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|01:27:42|24418435|24418435||1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.batch|24418435.batch|499092K|1|1Gn|"
-        "COMPLETED|01:27:29\n"
-        "|1|01:27:42|24418435.extern|24418435.extern|1376K|1|1Gn|"
-        "COMPLETED|00:00:00\n"
-        "|1|21:14:48|25569410|25569410||1|4000Mc|RUNNING|19:28:36\n"
-        "|1|21:14:49|25569410.extern|25569410.extern|1548K|1|4000Mc|"
-        "RUNNING|00:00:00\n"
-        "|1|21:14:43|25569410.0|25569410.0|62328K|1|4000Mc|RUNNING|19:28:36\n"
+        "^|^1^|^01:27:42^|^24418435^|^24418435^|^^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.batch^|^24418435.batch^|^499092K^|^1^|^1Gn^|^"
+        "COMPLETED^|^01:27:29\n"
+        "^|^1^|^01:27:42^|^24418435.extern^|^24418435.extern^|^1376K^|^1^|^1Gn^|^"
+        "COMPLETED^|^00:00:00\n"
+        "^|^1^|^21:14:48^|^25569410^|^25569410^|^^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
+        "^|^1^|^21:14:49^|^25569410.extern^|^25569410.extern"
+        "^|^1548K^|^1^|^4000Mc^|^RUNNING^|^00:00:00\n"
+        "^|^1^|^21:14:43^|^25569410.0^|^25569410.0^|^62328K"
+        "^|^1^|^4000Mc^|^RUNNING^|^19:28:36\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -634,12 +645,12 @@ def test_array_job_raw_id(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|00:09:34|24220929_421|24221219||1|16000Mn|"
-        "COMPLETED|09:28.052\n"
-        "|1|00:09:34|24220929_421.batch|24221219.batch|5664932K|1|16000Mn|"
-        "COMPLETED|09:28.051\n"
-        "|1|00:09:34|24220929_421.extern|24221219.extern|1404K|1|16000Mn|"
-        "COMPLETED|00:00:00\n"
+        "^|^1^|^00:09:34^|^24220929_421^|^24221219^|^^|^1^|^16000Mn^|^"
+        "COMPLETED^|^09:28.052\n"
+        "^|^1^|^00:09:34^|^24220929_421.batch^|^24221219.batch"
+        "^|^5664932K^|^1^|^16000Mn^|^COMPLETED^|^09:28.051\n"
+        "^|^1^|^00:09:34^|^24220929_421.extern^|^24221219.extern"
+        "^|^1404K^|^1^|^16000Mn^|^COMPLETED^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -667,18 +678,18 @@ def test_array_job_single(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|00:09:34|24220929_421|24221219||1|16000Mn|"
-        "COMPLETED|09:28.052\n"
-        "|1|00:09:34|24220929_421.batch|24221219.batch|5664932K|1|16000Mn|"
-        "COMPLETED|09:28.051\n"
-        "|1|00:09:34|24220929_421.extern|24221219.extern|1404K|1|16000Mn|"
-        "COMPLETED|00:00:00\n"
-        "|1|00:09:33|24220929_431|24221220||1|16000Mn|"
-        "PENDING|09:27.460\n"
-        "|1|00:09:33|24220929_431.batch|24221220.batch|5518572K|1|16000Mn|"
-        "PENDING|09:27.459\n"
-        "|1|00:09:33|24220929_431.extern|24221220.extern|1400K|1|16000Mn|"
-        "PENDING|00:00:00\n"
+        "^|^1^|^00:09:34^|^24220929_421^|^24221219^|^^|^1^|^16000Mn^|^"
+        "COMPLETED^|^09:28.052\n"
+        "^|^1^|^00:09:34^|^24220929_421.batch^|^24221219.batch"
+        "^|^5664932K^|^1^|^16000Mn^|^COMPLETED^|^09:28.051\n"
+        "^|^1^|^00:09:34^|^24220929_421.extern^|^24221219.extern"
+        "^|^1404K^|^1^|^16000Mn^|^COMPLETED^|^00:00:00\n"
+        "^|^1^|^00:09:33^|^24220929_431^|^24221220^|^^|^1^|^16000Mn^|^"
+        "PENDING^|^09:27.460\n"
+        "^|^1^|^00:09:33^|^24220929_431.batch^|^24221220.batch"
+        "^|^5518572K^|^1^|^16000Mn^|^PENDING^|^09:27.459\n"
+        "^|^1^|^00:09:33^|^24220929_431.extern^|^24221220.extern"
+        "^|^1400K^|^1^|^16000Mn^|^PENDING^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -708,18 +719,18 @@ def test_array_job_base(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|1|00:09:34|24220929_421|24221219||1|16000Mn|"
-        "COMPLETED|09:28.052\n"
-        "|1|00:09:34|24220929_421.batch|24221219.batch|5664932K|1|16000Mn|"
-        "COMPLETED|09:28.051\n"
-        "|1|00:09:34|24220929_421.extern|24221219.extern|1404K|1|16000Mn|"
-        "COMPLETED|00:00:00\n"
-        "|1|00:09:33|24220929_431|24221220||1|16000Mn|"
-        "PENDING|09:27.460\n"
-        "|1|00:09:33|24220929_431.batch|24221220.batch|5518572K|1|16000Mn|"
-        "PENDING|09:27.459\n"
-        "|1|00:09:33|24220929_431.extern|24221220.extern|1400K|1|16000Mn|"
-        "PENDING|00:00:00\n"
+        "^|^1^|^00:09:34^|^24220929_421^|^24221219^|^^|^1^|^16000Mn^|^"
+        "COMPLETED^|^09:28.052\n"
+        "^|^1^|^00:09:34^|^24220929_421.batch^|^24221219.batch^|^"
+        "5664932K^|^1^|^16000Mn^|^COMPLETED^|^09:28.051\n"
+        "^|^1^|^00:09:34^|^24220929_421.extern^|^24221219.extern^|^"
+        "1404K^|^1^|^16000Mn^|^COMPLETED^|^00:00:00\n"
+        "^|^1^|^00:09:33^|^24220929_431^|^24221220^|^^|^1^|^16000Mn^|^"
+        "PENDING^|^09:27.460\n"
+        "^|^1^|^00:09:33^|^24220929_431.batch^|^24221220.batch^|^"
+        "5518572K^|^1^|^16000Mn^|^PENDING^|^09:27.459\n"
+        "^|^1^|^00:09:33^|^24220929_431.extern^|^24221220.extern^|^"
+        "1400K^|^1^|^16000Mn^|^PENDING^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(
@@ -785,11 +796,11 @@ def test_failed_no_mem(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|8|00:00:12|23000381|23000381||1|4000Mc|FAILED|00:00:00\n"
-        "|8|00:00:12|23000381.batch|23000381.batch||1|4000Mc|"
-        "FAILED|00:00:00\n"
-        "|8|00:00:12|23000381.extern|23000381.extern|1592K|1|4000Mc|"
-        "COMPLETED|00:00:00\n"
+        "^|^8^|^00:00:12^|^23000381^|^23000381^|^^|^1^|^4000Mc^|^FAILED^|^00:00:00\n"
+        "^|^8^|^00:00:12^|^23000381.batch^|^23000381.batch^|^^|^1^|^4000Mc^|^"
+        "FAILED^|^00:00:00\n"
+        "^|^8^|^00:00:12^|^23000381.extern^|^23000381.extern^|^1592K^|^1^|^4000Mc^|^"
+        "COMPLETED^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(console.main, "--no-color 23000381".split())
@@ -808,7 +819,8 @@ def test_canceled_by_other(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|16|00:00:00|23000233|23000233||1|4000Mc|CANCELLED by 129319|00:00:00\n"
+        "^|^16^|^00:00:00^|^23000233^|^23000233^|^^|^1^|^"
+        "4000Mc^|^CANCELLED by 129319^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(console.main, "--no-color 23000233 --state CA".split())
@@ -834,12 +846,12 @@ def test_zero_runtime(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|8|00:00:00|23000210|23000210||1|20000Mn|"
-        "FAILED|00:00.007\n"
-        "|8|00:00:00|23000210.batch|23000210.batch|1988K|1|20000Mn|"
-        "FAILED|00:00.006\n"
-        "|8|00:00:00|23000210.extern|23000210.extern|1556K|1|20000Mn|"
-        "COMPLETED|00:00:00\n"
+        "^|^8^|^00:00:00^|^23000210^|^23000210^|^^|^1^|^20000Mn^|^"
+        "FAILED^|^00:00.007\n"
+        "^|^8^|^00:00:00^|^23000210.batch^|^23000210.batch^|^1988K^|^1^|^20000Mn^|^"
+        "FAILED^|^00:00.006\n"
+        "^|^8^|^00:00:00^|^23000210.extern^|^23000210.extern^|^1556K^|^1^|^20000Mn^|^"
+        "COMPLETED^|^00:00:00\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(console.main, "--no-color 23000210".split())
@@ -869,47 +881,51 @@ def test_issue_16(mocker, mock_inquirer):
     runner = CliRunner()
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
-    sub_result.stdout = (
-        "|16|07:36:03|65638294|65638294||2|32G|COMPLETED|6-23:59:00|4-23:56:21\n"
-        "|1|07:36:03|65638294.batch|65638294.batch|1147220K|1||COMPLETED||07:30:20\n"
-        "|16|07:36:03|65638294.extern|65638294.extern|0|2||COMPLETED||00:00.001\n"
-        "|15|00:00:11|65638294.0|65638294.0|0|1||COMPLETED||00:11.830\n"
-        "|15|00:02:15|65638294.1|65638294.1|4455540K|1||COMPLETED||31:09.458\n"
-        "|15|00:00:10|65638294.2|65638294.2|0|1||COMPLETED||00:00:04\n"
-        "|15|00:00:08|65638294.3|65638294.3|0|1||COMPLETED||00:09.602\n"
-        "|15|00:00:07|65638294.4|65638294.4|0|1||COMPLETED||00:56.827\n"
-        "|15|00:00:06|65638294.5|65638294.5|0|1||COMPLETED||00:03.512\n"
-        "|15|00:00:08|65638294.6|65638294.6|0|1||COMPLETED||00:08.520\n"
-        "|15|00:00:13|65638294.7|65638294.7|0|1||COMPLETED||01:02.013\n"
-        "|15|00:00:02|65638294.8|65638294.8|0|1||COMPLETED||00:03.639\n"
-        "|15|00:00:06|65638294.9|65638294.9|0|1||COMPLETED||00:08.683\n"
-        "|15|00:00:08|65638294.10|65638294.10|0|1||COMPLETED||00:57.438\n"
-        "|15|00:00:06|65638294.11|65638294.11|0|1||COMPLETED||00:03.642\n"
-        "|15|00:00:09|65638294.12|65638294.12|0|1||COMPLETED||00:10.271\n"
-        "|15|00:01:24|65638294.13|65638294.13|4149700K|1||COMPLETED||17:18.067\n"
-        "|15|00:00:01|65638294.14|65638294.14|0|1||COMPLETED||00:03.302\n"
-        "|15|00:00:10|65638294.15|65638294.15|0|1||COMPLETED||00:14.615\n"
-        "|15|00:06:45|65638294.16|65638294.16|4748052K|1||COMPLETED||01:36:40\n"
-        "|15|00:00:10|65638294.17|65638294.17|0|1||COMPLETED||00:03.864\n"
-        "|15|00:00:09|65638294.18|65638294.18|0|1||COMPLETED||00:48.987\n"
-        "|15|01:32:53|65638294.19|65638294.19|7734356K|1||COMPLETED||23:09:33\n"
-        "|15|00:00:01|65638294.20|65638294.20|0|1||COMPLETED||00:03.520\n"
-        "|15|00:00:07|65638294.21|65638294.21|0|1||COMPLETED||00:50.015\n"
-        "|15|00:55:17|65638294.22|65638294.22|8074500K|1||COMPLETED||13:45:29\n"
-        "|15|00:00:13|65638294.23|65638294.23|0|1||COMPLETED||00:04.413\n"
-        "|15|00:00:12|65638294.24|65638294.24|0|1||COMPLETED||00:49.100\n"
-        "|15|00:57:41|65638294.25|65638294.25|7883152K|1||COMPLETED||14:20:36\n"
-        "|15|00:00:01|65638294.26|65638294.26|0|1||COMPLETED||00:03.953\n"
-        "|15|00:00:05|65638294.27|65638294.27|0|1||COMPLETED||00:47.223\n"
-        "|15|01:00:17|65638294.28|65638294.28|7715752K|1||COMPLETED||14:59:40\n"
-        "|15|00:00:06|65638294.29|65638294.29|0|1||COMPLETED||00:04.341\n"
-        "|15|00:00:07|65638294.30|65638294.30|0|1||COMPLETED||00:50.416\n"
-        "|15|01:22:31|65638294.31|65638294.31|7663264K|1||COMPLETED||20:33:59\n"
-        "|15|00:00:05|65638294.32|65638294.32|0|1||COMPLETED||00:04.199\n"
-        "|15|00:00:08|65638294.33|65638294.33|0|1||COMPLETED||00:50.009\n"
-        "|15|01:32:23|65638294.34|65638294.34|7764884K|1||COMPLETED||23:01:52\n"
-        "|15|00:00:06|65638294.35|65638294.35|0|1||COMPLETED||00:04.527\n"
-    )
+    sub_result.stdout = """
+^|^16^|^07:36:03^|^65638294^|^65638294^|^^|^2^|^32G\
+^|^COMPLETED^|^6-23:59:00^|^4-23:56:21
+^|^1^|^07:36:03^|^65638294.batch^|^65638294.batch\
+^|^1147220K^|^1^|^^|^COMPLETED^|^^|^07:30:20
+^|^16^|^07:36:03^|^65638294.extern^|^65638294.extern\
+^|^0^|^2^|^^|^COMPLETED^|^^|^00:00.001
+^|^15^|^00:00:11^|^65638294.0^|^65638294.0^|^0^|^1^|^^|^COMPLETED^|^^|^00:11.830
+^|^15^|^00:02:15^|^65638294.1^|^65638294.1^|^4455540K^|^1^|^^|^COMPLETED^|^^|^31:09.458
+^|^15^|^00:00:10^|^65638294.2^|^65638294.2^|^0^|^1^|^^|^COMPLETED^|^^|^00:00:04
+^|^15^|^00:00:08^|^65638294.3^|^65638294.3^|^0^|^1^|^^|^COMPLETED^|^^|^00:09.602
+^|^15^|^00:00:07^|^65638294.4^|^65638294.4^|^0^|^1^|^^|^COMPLETED^|^^|^00:56.827
+^|^15^|^00:00:06^|^65638294.5^|^65638294.5^|^0^|^1^|^^|^COMPLETED^|^^|^00:03.512
+^|^15^|^00:00:08^|^65638294.6^|^65638294.6^|^0^|^1^|^^|^COMPLETED^|^^|^00:08.520
+^|^15^|^00:00:13^|^65638294.7^|^65638294.7^|^0^|^1^|^^|^COMPLETED^|^^|^01:02.013
+^|^15^|^00:00:02^|^65638294.8^|^65638294.8^|^0^|^1^|^^|^COMPLETED^|^^|^00:03.639
+^|^15^|^00:00:06^|^65638294.9^|^65638294.9^|^0^|^1^|^^|^COMPLETED^|^^|^00:08.683
+^|^15^|^00:00:08^|^65638294.10^|^65638294.10^|^0^|^1^|^^|^COMPLETED^|^^|^00:57.438
+^|^15^|^00:00:06^|^65638294.11^|^65638294.11^|^0^|^1^|^^|^COMPLETED^|^^|^00:03.642
+^|^15^|^00:00:09^|^65638294.12^|^65638294.12^|^0^|^1^|^^|^COMPLETED^|^^|^00:10.271
+^|^15^|^00:01:24^|^65638294.13^|^65638294.13^|^4149700K\
+^|^1^|^^|^COMPLETED^|^^|^17:18.067
+^|^15^|^00:00:01^|^65638294.14^|^65638294.14^|^0^|^1^|^^|^COMPLETED^|^^|^00:03.302
+^|^15^|^00:00:10^|^65638294.15^|^65638294.15^|^0^|^1^|^^|^COMPLETED^|^^|^00:14.615
+^|^15^|^00:06:45^|^65638294.16^|^65638294.16^|^4748052K^|^1^|^^|^COMPLETED^|^^|^01:36:40
+^|^15^|^00:00:10^|^65638294.17^|^65638294.17^|^0^|^1^|^^|^COMPLETED^|^^|^00:03.864
+^|^15^|^00:00:09^|^65638294.18^|^65638294.18^|^0^|^1^|^^|^COMPLETED^|^^|^00:48.987
+^|^15^|^01:32:53^|^65638294.19^|^65638294.19^|^7734356K^|^1^|^^|^COMPLETED^|^^|^23:09:33
+^|^15^|^00:00:01^|^65638294.20^|^65638294.20^|^0^|^1^|^^|^COMPLETED^|^^|^00:03.520
+^|^15^|^00:00:07^|^65638294.21^|^65638294.21^|^0^|^1^|^^|^COMPLETED^|^^|^00:50.015
+^|^15^|^00:55:17^|^65638294.22^|^65638294.22^|^8074500K^|^1^|^^|^COMPLETED^|^^|^13:45:29
+^|^15^|^00:00:13^|^65638294.23^|^65638294.23^|^0^|^1^|^^|^COMPLETED^|^^|^00:04.413
+^|^15^|^00:00:12^|^65638294.24^|^65638294.24^|^0^|^1^|^^|^COMPLETED^|^^|^00:49.100
+^|^15^|^00:57:41^|^65638294.25^|^65638294.25^|^7883152K^|^1^|^^|^COMPLETED^|^^|^14:20:36
+^|^15^|^00:00:01^|^65638294.26^|^65638294.26^|^0^|^1^|^^|^COMPLETED^|^^|^00:03.953
+^|^15^|^00:00:05^|^65638294.27^|^65638294.27^|^0^|^1^|^^|^COMPLETED^|^^|^00:47.223
+^|^15^|^01:00:17^|^65638294.28^|^65638294.28^|^7715752K^|^1^|^^|^COMPLETED^|^^|^14:59:40
+^|^15^|^00:00:06^|^65638294.29^|^65638294.29^|^0^|^1^|^^|^COMPLETED^|^^|^00:04.341
+^|^15^|^00:00:07^|^65638294.30^|^65638294.30^|^0^|^1^|^^|^COMPLETED^|^^|^00:50.416
+^|^15^|^01:22:31^|^65638294.31^|^65638294.31^|^7663264K^|^1^|^^|^COMPLETED^|^^|^20:33:59
+^|^15^|^00:00:05^|^65638294.32^|^65638294.32^|^0^|^1^|^^|^COMPLETED^|^^|^00:04.199
+^|^15^|^00:00:08^|^65638294.33^|^65638294.33^|^0^|^1^|^^|^COMPLETED^|^^|^00:50.009
+^|^15^|^01:32:23^|^65638294.34^|^65638294.34^|^7764884K^|^1^|^^|^COMPLETED^|^^|^23:01:52
+^|^15^|^00:00:06^|^65638294.35^|^65638294.35^|^0^|^1^|^^|^COMPLETED^|^^|^00:04.527
+"""
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(console.main, "--no-color 65638294".split())
 
@@ -934,30 +950,30 @@ def test_energy_reporting(mocker, mock_inquirer):
     sub_result = mocker.MagicMock()
     sub_result.returncode = 0
     sub_result.stdout = (
-        "|32|00:01:09|37403870_1|37403937||1|32000M|"
-        "COMPLETED||00:02:00|00:47.734\n"
-        "|32|00:01:09|37403870_1.batch|37403937.batch|6300K|1||"
-        "COMPLETED|energy=33,fs/disk=0||00:47.733\n"
-        "|32|00:01:09|37403870_1.extern|37403937.extern|4312K|1||"
-        "COMPLETED|energy=33,fs/disk=0||00:00.001\n"
-        "|32|00:01:21|37403870_2|37403938||1|32000M|"
-        "COMPLETED||00:02:00|00:41.211\n"
-        "|32|00:01:21|37403870_2.batch|37403938.batch|6316K|1||"
-        "COMPLETED|energy=32,fs/disk=0||00:41.210\n"
-        "|32|00:01:21|37403870_2.extern|37403938.extern|4312K|1||"
-        "COMPLETED|energy=32,fs/disk=0||00:00:00\n"
-        "|32|00:01:34|37403870_3|37403939||1|32000M|"
-        "COMPLETED||00:02:00|00:51.669\n"
-        "|32|00:01:34|37403870_3.batch|37403939.batch|6184K|1||"
-        "COMPLETED|energy=30,fs/disk=0||00:51.667\n"
-        "|32|00:01:35|37403870_3.extern|37403939.extern|4312K|1||"
-        "COMPLETED|fs/disk=0,energy=30||00:00.001\n"
-        "|32|00:01:11|37403870_4|37403870||1|32000M|"
-        "COMPLETED||00:02:00|01:38.184\n"
-        "|32|00:01:11|37403870_4.batch|37403870.batch|6300K|1||"
-        "COMPLETED|fs/disk=0||01:38.183\n"
-        "|32|00:01:11|37403870_4.extern|37403870.extern|4312K|1||"
-        "COMPLETED|energy=27,fs/disk=0||00:00.001\n"
+        "^|^32^|^00:01:09^|^37403870_1^|^37403937^|^^|^1^|^32000M^|^"
+        "COMPLETED^|^^|^00:02:00^|^00:47.734\n"
+        "^|^32^|^00:01:09^|^37403870_1.batch^|^37403937.batch^|^6300K^|^1^|^^|^"
+        "COMPLETED^|^energy=33,fs/disk=0^|^^|^00:47.733\n"
+        "^|^32^|^00:01:09^|^37403870_1.extern^|^37403937.extern^|^4312K^|^1^|^^|^"
+        "COMPLETED^|^energy=33,fs/disk=0^|^^|^00:00.001\n"
+        "^|^32^|^00:01:21^|^37403870_2^|^37403938^|^^|^1^|^32000M^|^"
+        "COMPLETED^|^^|^00:02:00^|^00:41.211\n"
+        "^|^32^|^00:01:21^|^37403870_2.batch^|^37403938.batch^|^6316K^|^1^|^^|^"
+        "COMPLETED^|^energy=32,fs/disk=0^|^^|^00:41.210\n"
+        "^|^32^|^00:01:21^|^37403870_2.extern^|^37403938.extern^|^4312K^|^1^|^^|^"
+        "COMPLETED^|^energy=32,fs/disk=0^|^^|^00:00:00\n"
+        "^|^32^|^00:01:34^|^37403870_3^|^37403939^|^^|^1^|^32000M^|^"
+        "COMPLETED^|^^|^00:02:00^|^00:51.669\n"
+        "^|^32^|^00:01:34^|^37403870_3.batch^|^37403939.batch^|^6184K^|^1^|^^|^"
+        "COMPLETED^|^energy=30,fs/disk=0^|^^|^00:51.667\n"
+        "^|^32^|^00:01:35^|^37403870_3.extern^|^37403939.extern^|^4312K^|^1^|^^|^"
+        "COMPLETED^|^fs/disk=0,energy=30^|^^|^00:00.001\n"
+        "^|^32^|^00:01:11^|^37403870_4^|^37403870^|^^|^1^|^32000M^|^"
+        "COMPLETED^|^^|^00:02:00^|^01:38.184\n"
+        "^|^32^|^00:01:11^|^37403870_4.batch^|^37403870.batch^|^6300K^|^1^|^^|^"
+        "COMPLETED^|^fs/disk=0^|^^|^01:38.183\n"
+        "^|^32^|^00:01:11^|^37403870_4.extern^|^37403870.extern^|^4312K^|^1^|^^|^"
+        "COMPLETED^|^energy=27,fs/disk=0^|^^|^00:00.001\n"
     )
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
     result = runner.invoke(console.main, "--no-color --format=+energy 37403870".split())


### PR DESCRIPTION
Changed the delimiter passed to sacct to `^|^`.
Setting the parsable option on reportseff still outputs info joined by a single `|`.