### PR TITLE
Add delimiter flag

### DIFF
--- a/src/reportseff/console.py
+++ b/src/reportseff/console.py
@@ -140,6 +140,7 @@ def main(**kwargs: Any) -> None:
     """Main entry point for reportseff."""
     if kwargs.get("delimiter") != " " and not kwargs.get("parsable"):
         click.echo("WARNING: --delimiter will be ignored since it can only be used with --parsable.", err=True)
+        kwargs["delimiter"] = " "
     elif kwargs.get("delimiter") == " " and kwargs.get("parsable"):
         kwargs["delimiter"] = "|"
     args = ReportseffParameters(**kwargs)

--- a/src/reportseff/output_renderer.py
+++ b/src/reportseff/output_renderer.py
@@ -38,6 +38,7 @@ class OutputRenderer:
         node: bool = False,
         gpu: bool = False,
         parsable: bool = False,
+        delimiter: str = " ",
     ) -> None:
         """Initialize renderer with format string and list of valid titles.
 
@@ -64,6 +65,7 @@ class OutputRenderer:
         }
 
         self.parsable = parsable
+        self.delimiter = delimiter
 
         # build formatters
         self.formatters = build_formatters(format_str)
@@ -137,7 +139,7 @@ class OutputRenderer:
             Formatted table as single string
         """
         result = ""
-        delimiter = "|" if self.parsable else " "
+        delimiter = self.delimiter
 
         if len(self.formatters) == 0:
             return result

--- a/src/reportseff/parameters.py
+++ b/src/reportseff/parameters.py
@@ -20,6 +20,7 @@ class ReportseffParameters:
     node_and_gpu: bool = False
     not_state: str = ""
     parsable: bool = False
+    delimiter: str = ""
     since: str = ""
     until: str = ""
     state: str = ""


### PR DESCRIPTION
Hi,
First of all, thank you very much for developing this, we are using it for a lot of reporting in our cluster and it's a great package :)

There are some users that use crazy names for their jobs, also including "|". In these cases the default delimiter used with `--parsable` causes the output to not be usable for processing data since some rows are interpreted as having more columns.

I have added a flag to set a custom delimiter.

Let me know if it looks good to you.