### PR TITLE
feat: add jobid sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ split_ubam_24419972     RUNNING        01:26:26    ---      ---
 
 Without arguments, reportseff will try to find slurm output files in the
 current directory. Combine with `watch` to monitor job progress:
-`watch -cn 300 reportseff --color --modified-sort`
+`watch -cn 300 reportseff --color --sorting mtime`
 
 ```txt
                 JobID           State          Elapsed   CPUEff   MemEff
@@ -189,8 +189,10 @@ directory to check for slurm outputs.
 - `--color/--no-color`: Force color output or not.  By default, will force color
   output.  With the no-color flag, click will strip color codes for everything
   besides stdout.
-- `--modified-sort`: Instead of sorting by filename/jobid, sort by last
-  modification time of the slurm output file.
+- `--sorting`: By default, slurmise will sort output jobs by their slurm job ids.
+  You may also set this to `--sorting mtime` to sort by last modification time
+  of the slurm output file or `--sorting filename` to perform a lexicographical
+  sort on the filename.
 - `--debug`: Write sacct result to stderr.
 - `--user/-u`: Ignore job arguments and instead query sacct with provided user.
   Returns all jobs from the last week.
@@ -265,7 +267,7 @@ are some useful settings for your `.bashrc`:
 # have less display colors by default.  Will fix `reportseff` not showing colors
 export LESS="-R"
 # for watch aliases, include the `--color` option
-watch -cn 300 reportseff --color --modified-sort
+watch -cn 300 reportseff --color --sorting mtime
 #      ^                 ^^^^^^^
 ```
 You can always for display of color (or suppress it) with the `--color/--no-color`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reportseff"
-version = "2.9.0"
+version = "2.10.0"
 description= "Tablular seff output"
 authors = ["Troy Comi <troycomi@gmail.com>"]
 license = "MIT"

--- a/src/reportseff/console.py
+++ b/src/reportseff/console.py
@@ -19,10 +19,15 @@ MAX_ENTRIES_TO_ECHO = 20
 
 @click.command()
 @click.option(
-    "--modified-sort",
-    default=False,
-    is_flag=True,
-    help="If set, will sort outputs by modified time of files",
+    "--sorting",
+    default="jobid",
+    help=(
+        "One of mtime, filename or jobid.  Controls how jobs are reported."
+        "If mtime will sort by the modified time of the file or job number"
+        "If filename will sort by the if the file exists,"
+        "the length, then the content."
+        "If jobid [default] split the job name and cast all numerics to ints"
+    ),
 )
 @click.option(
     "--color/--no-color",
@@ -226,7 +231,7 @@ def get_jobs(args: ReportseffParameters) -> tuple[str, int]:
     if args.array_min_size > 0:
         job_collection.filter_by_array_size(args.array_min_size)
 
-    found_jobs = job_collection.get_sorted_jobs(change_sort=args.modified_sort)
+    found_jobs = job_collection.get_sorted_jobs(sorting=args.sorting)
     found_jobs = [j for j in found_jobs if j.state]
 
     return renderer.format_jobs(found_jobs), len(found_jobs)

--- a/src/reportseff/parameters.py
+++ b/src/reportseff/parameters.py
@@ -15,7 +15,7 @@ class ReportseffParameters:
     jobs: tuple
     debug: bool = False
     format_str: str = ""
-    modified_sort: bool = False
+    sorting: str = "jobid"
     node: bool = False
     node_and_gpu: bool = False
     not_state: str = ""

--- a/tests/test_job_collection.py
+++ b/tests/test_job_collection.py
@@ -458,7 +458,7 @@ def test_get_sorted_jobs(jobs, mocker):
     jobs.add_job("j2", "jid2")
     jobs.add_job("j13", "jid13")
 
-    assert jobs.get_sorted_jobs(change_sort=False) == [
+    assert jobs.get_sorted_jobs(sorting="filename") == [
         Job("j1", "jid1", None),
         Job("j2", "jid2", None),
         Job("j3", "jid3", None),
@@ -490,7 +490,7 @@ def test_get_sorted_jobs(jobs, mocker):
     )
 
     # still uses other sorting, no dir_name set
-    assert jobs.get_sorted_jobs(change_sort=True) == [
+    assert jobs.get_sorted_jobs(sorting="mtime") == [
         Job("j13", "jid13", None),
         Job("j2", "jid2", "file234"),
         Job("j14", "jid14", "nothing"),
@@ -499,12 +499,104 @@ def test_get_sorted_jobs(jobs, mocker):
     ]
 
     jobs.dir_name = Path("dir")  # now dir/nothing doesn't exist
-    assert jobs.get_sorted_jobs(change_sort=True) == [
+    assert jobs.get_sorted_jobs(sorting="mtime") == [
         Job("j14", "jid14", "nothing"),
         Job("j13", "jid13", None),
         Job("j2", "jid2", "file234"),
         Job("j1", "jid1", "file12"),
         Job("j3", "jid3", "file3"),
+    ]
+
+
+def test_get_sorted_jobs_jobid(jobs):
+    """Can get jobs in sorted order by numeric job id."""
+    jobs.add_job("3", "1_2")
+    jobs.add_job("2", "1_1")
+    jobs.add_job("1", "1")
+    jobs.add_job("4", "2")
+    jobs.add_job("5", "2_100")
+    jobs.add_job("7", "a_2_100")
+    jobs.add_job("6", "a2_100")
+
+    assert jobs.get_sorted_jobs(sorting="jobid") == [
+        Job("7", "a_2_100", None),
+        Job("6", "a2_100", None),
+        Job("1", "1", None),
+        Job("2", "1_1", None),
+        Job("3", "1_2", None),
+        Job("4", "2", None),
+        Job("5", "2_100", None),
+    ]
+
+
+def test_get_sorted_jobs_issue_75(jobs):
+    """Test specific example from issue 75."""
+    jobs.add_job("1", "5163879_8")
+    jobs.add_job("2", "5163879_6")
+    jobs.add_job("3", "5163879_4")
+    jobs.add_job("4", "5163879_2")
+    jobs.add_job("5", "5163879_15")
+    jobs.add_job("6", "5163879_14")
+    jobs.add_job("7", "5163879_13")
+    jobs.add_job("8", "5163879_12")
+    jobs.add_job("9", "5163879_11")
+    jobs.add_job("10", "5163879_10")
+    jobs.add_job("11", "5163543_20")
+    jobs.add_job("12", "5163543_19")
+    jobs.add_job("13", "5163543_18")
+    jobs.add_job("14", "5163543_17")
+    jobs.add_job("15", "5163543_16")
+    jobs.add_job("16", "5163543_15")
+    jobs.add_job("17", "5163543_14")
+    jobs.add_job("18", "5163543_13")
+    jobs.add_job("19", "5163543_12")
+    jobs.add_job("20", "5163543_11")
+    jobs.add_job("21", "5163543_10")
+    jobs.add_job("22", "5159883_8")
+    jobs.add_job("23", "5159883_6")
+    jobs.add_job("24", "5159883_4")
+    jobs.add_job("25", "5159883_2")
+    jobs.add_job("26", "5159883_20")
+    jobs.add_job("27", "5159883_18")
+    jobs.add_job("28", "5159883_16")
+    jobs.add_job("29", "5159883_14")
+    jobs.add_job("30", "5159883_12")
+    jobs.add_job("31", "5159883_10")
+    jobs.add_job("32", "5159883_0")
+
+    assert jobs.get_sorted_jobs(sorting="jobid") == [
+        Job("32", "5159883_0", None),
+        Job("25", "5159883_2", None),
+        Job("24", "5159883_4", None),
+        Job("23", "5159883_6", None),
+        Job("22", "5159883_8", None),
+        Job("31", "5159883_10", None),
+        Job("30", "5159883_12", None),
+        Job("29", "5159883_14", None),
+        Job("28", "5159883_16", None),
+        Job("27", "5159883_18", None),
+        Job("26", "5159883_20", None),
+        Job("21", "5163543_10", None),
+        Job("20", "5163543_11", None),
+        Job("19", "5163543_12", None),
+        Job("18", "5163543_13", None),
+        Job("17", "5163543_14", None),
+        Job("16", "5163543_15", None),
+        Job("15", "5163543_16", None),
+        Job("14", "5163543_17", None),
+        Job("13", "5163543_18", None),
+        Job("12", "5163543_19", None),
+        Job("11", "5163543_20", None),
+        Job("4", "5163879_2", None),
+        Job("3", "5163879_4", None),
+        Job("2", "5163879_6", None),
+        Job("1", "5163879_8", None),
+        Job("10", "5163879_10", None),
+        Job("9", "5163879_11", None),
+        Job("8", "5163879_12", None),
+        Job("7", "5163879_13", None),
+        Job("6", "5163879_14", None),
+        Job("5", "5163879_15", None),
     ]
 
 


### PR DESCRIPTION
Change the modified sort flag to accept different options
Changed default ordering to use the jobid of the slurm job
the new sorting option can accept mtime, filename or jobid