### PR TITLE
Feat/jobstats fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 *.swp
 .python-version
 .coverage
+work/
+# ignore the .vscode folder, which is used by Visual Studio Code for project settings
+.vscode/

--- a/README.md
+++ b/README.md
@@ -228,6 +228,12 @@ directory to check for slurm outputs.
   requires additional sacct fields from jobstats.
 - `--parsable/-p`: Ignore formatting and output as a `|` delimited table.  Useful
   for piping into more complex analyses.
+- `--no-jobstats-fallback`: Disable the fallback mechanism that recovers GPU metrics
+  from jobstats when they are not present in Slurm's AdminComment field. By default,
+  if `jobstats` is available on the system, reportseff will attempt to fetch GPU
+  metrics via `jobstats <jobid> -b` when the AdminComment field is empty. This flag
+  disables that behavior. Useful if jobstats queries cause excessive load or if you
+  prefer to rely only on cached AdminComment data.
 
 ## Status, Contributions, and Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 keywords= ["slurm","seff"]
 requires-python = ">=3.10"
 dependencies = [
-    "click>=6.7",
+    "click>=6.7,!=8.3.0,!=8.3.1,!=8.3.2",
 ]
 
 [project.scripts]

--- a/src/reportseff/console.py
+++ b/src/reportseff/console.py
@@ -9,7 +9,7 @@ from typing import Any
 import click
 
 from . import __version__
-from .db_inquirer import BaseInquirer, SacctInquirer
+from .db_inquirer import BaseInquirer, SacctInquirer, _check_jobstats_available, augment_with_jobstats
 from .job_collection import JobCollection
 from .output_renderer import OutputRenderer, RenderOptions
 from .parameters import ReportseffParameters
@@ -148,6 +148,16 @@ MAX_ENTRIES_TO_ECHO = 20
     help="Only include array jobs with at least this many tasks. "
     "Non-array jobs are always included. Set to 0 to include all jobs (default).",
 )
+@click.option(
+    "--no-jobstats-fallback",
+    "no_jobstats_fallback",
+    is_flag=True,
+    default=False,
+    help="Disable the jobstats fallback for GPU metrics. "
+    "By default, when AdminComment is absent reportseff will attempt to "
+    "recover GPU efficiency data by calling `jobstats -b`. "
+    "Pass this flag to suppress that behaviour.",
+)
 @click.version_option(version=__version__)
 @click.argument("jobs", nargs=-1)
 def main(**kwargs: Any) -> None:
@@ -219,6 +229,11 @@ def get_jobs(args: ReportseffParameters) -> tuple[str, int]:
         job_collection,
         debug=args.debug,
     )
+
+    if not args.no_jobstats_fallback and _check_jobstats_available():
+        debug_cmd = (lambda msg: click.echo(msg, err=True)) if args.debug else None
+        db_output = augment_with_jobstats(db_output, debug_cmd=debug_cmd)
+
     entry = None
     try:
         for entry in db_output:

--- a/src/reportseff/console.py
+++ b/src/reportseff/console.py
@@ -9,7 +9,12 @@ from typing import Any
 import click
 
 from . import __version__
-from .db_inquirer import BaseInquirer, SacctInquirer, _check_jobstats_available, augment_with_jobstats
+from .db_inquirer import (
+    BaseInquirer,
+    SacctInquirer,
+    _check_jobstats_available,
+    augment_with_jobstats,
+)
 from .job_collection import JobCollection
 from .output_renderer import OutputRenderer, RenderOptions
 from .parameters import ReportseffParameters

--- a/src/reportseff/db_inquirer.py
+++ b/src/reportseff/db_inquirer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import re
 import shlex
+import shutil
 import subprocess
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
@@ -13,6 +14,131 @@ import click
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+# Fallback mechanism for GPU metrics recovery.
+# Jobstats is migrating GPU metrics storage from Slurm AdminComment to Prometheus.
+# See: https://github.com/PrincetonUniversity/jobstats/pull/55
+# When the optional mirror_to_admin_comment config flag is not enabled,
+# reportseff can recover GPU metrics from jobstats via the -b flag.
+# This allows continued GPU efficiency reporting even if AdminComment is unavailable.
+
+# Minimum length for a valid AdminComment payload (mirrors job.ADMIN_COMMENT_MIN_LENGTH)
+_ADMIN_COMMENT_MIN_LENGTH = 10
+
+# Module-level cache so the availability check runs at most once per process.
+_JOBSTATS_AVAILABLE: bool | None = None
+
+
+def _check_jobstats_available() -> bool:
+    """Return True if `jobstats -b` is usable on the current PATH.
+
+    The result is cached after the first call so subsequent invocations are
+    free.
+
+    Returns:
+        True when `jobstats` is found on PATH **and** its help text confirms
+        the ``-b`` / ``--base64`` flag is present.
+    """
+    global _JOBSTATS_AVAILABLE  # noqa: PLW0603
+    if _JOBSTATS_AVAILABLE is not None:
+        return _JOBSTATS_AVAILABLE
+
+    if shutil.which("jobstats") is None:
+        _JOBSTATS_AVAILABLE = False
+        return False
+
+    try:
+        result = subprocess.run(
+            ["jobstats", "-h"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="utf8",
+            timeout=10,
+        )
+        help_text = result.stdout
+    except Exception:  # noqa: BLE001
+        _JOBSTATS_AVAILABLE = False
+        return False
+
+    _JOBSTATS_AVAILABLE = "--base64" in help_text or "-b" in help_text
+    return _JOBSTATS_AVAILABLE
+
+
+def augment_with_jobstats(
+    rows: list[dict[str, str]],
+    *,
+    debug_cmd: "Callable[[str], Any] | None" = None,
+) -> list[dict[str, str]]:
+    """Fill missing AdminComment values using `jobstats -b`.
+
+    For rows whose ``AdminComment`` is absent or shorter than the minimum
+    threshold, this function calls ``jobstats <id1> <id2> … -b`` in a single
+    subprocess and injects the returned base64 payloads back as
+    ``JS1:<payload>``, which is the format expected by
+    :func:`~reportseff.job._parse_admin_comment_to_dict`.
+
+    The subprocess call is batched (one fork for all missing rows) to avoid
+    spawning one process per array-job task.  jobstats processes IDs in order
+    and prints each result before moving to the next, so on a partial failure
+    the output lines map positionally to the *first K* input IDs.
+
+    Args:
+        rows: sacct rows as returned by :meth:`SacctInquirer.get_db_output`.
+        debug_cmd: optional callable to receive a debug message.
+
+    Returns:
+        The same list with ``AdminComment`` updated in-place for matched rows.
+    """
+    # Collect rows that need augmentation.  Skip .batch/.extern sub-steps
+    # (JobIDRaw is empty or equals the parent) and rows already having data.
+    missing_idx: list[int] = []
+    missing_rawids: list[str] = []
+
+    for i, row in enumerate(rows):
+        admin = row.get("AdminComment", "")
+        rawid = row.get("JobIDRaw", "")
+        if (
+            len(admin) <= _ADMIN_COMMENT_MIN_LENGTH
+            and rawid
+            and "." not in row.get("JobID", "")
+        ):
+            missing_idx.append(i)
+            missing_rawids.append(rawid)
+
+    if not missing_rawids:
+        return rows
+
+    if debug_cmd is not None:
+        debug_cmd(
+            f"jobstats fallback: fetching GPU metrics for "
+            f"{len(missing_rawids)} job(s) via `jobstats -b`"
+        )
+
+    try:
+        proc = subprocess.run(
+            ["jobstats", *missing_rawids, "-b"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf8",
+        )
+    except Exception:  # noqa: BLE001
+        # jobstats unavailable or crashed entirely — leave rows unchanged.
+        return rows
+
+    output_lines = [line for line in proc.stdout.splitlines() if line]
+
+    # Map lines back to input IDs positionally.  jobstats exits on the first
+    # failure so stdout may contain fewer lines than requested.
+    for list_pos, row_idx in enumerate(missing_idx):
+        if list_pos >= len(output_lines):
+            break
+        payload = output_lines[list_pos]
+        # Skip jobstats sentinel values.
+        if payload in ("None", "Short"):
+            continue
+        rows[row_idx]["AdminComment"] = "JS1:" + payload
+
+    return rows
 
 
 class BaseInquirer(ABC):

--- a/src/reportseff/db_inquirer.py
+++ b/src/reportseff/db_inquirer.py
@@ -43,17 +43,19 @@ def _check_jobstats_available() -> bool:
     if _JOBSTATS_AVAILABLE is not None:
         return _JOBSTATS_AVAILABLE
 
-    if shutil.which("jobstats") is None:
+    jobstats_path = shutil.which("jobstats")
+    if jobstats_path is None:
         _JOBSTATS_AVAILABLE = False
         return False
 
     try:
-        result = subprocess.run(
-            ["jobstats", "-h"],
+        result = subprocess.run(  # noqa: S603
+            [jobstats_path, "-h"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             encoding="utf8",
             timeout=10,
+            check=False,
         )
         help_text = result.stdout
     except Exception:  # noqa: BLE001
@@ -67,7 +69,7 @@ def _check_jobstats_available() -> bool:
 def augment_with_jobstats(
     rows: list[dict[str, str]],
     *,
-    debug_cmd: "Callable[[str], Any] | None" = None,
+    debug_cmd: Callable[[str], Any] | None = None,
 ) -> list[dict[str, str]]:
     """Fill missing AdminComment values using `jobstats -b`.
 
@@ -114,12 +116,16 @@ def augment_with_jobstats(
             f"{len(missing_rawids)} job(s) via `jobstats -b`"
         )
 
+    jobstats_path = shutil.which("jobstats")
+    if jobstats_path is None:
+        return rows
+
     try:
-        proc = subprocess.run(
-            ["jobstats", *missing_rawids, "-b"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        proc = subprocess.run(  # noqa: S603
+            [jobstats_path, *missing_rawids, "-b"],
+            capture_output=True,
             encoding="utf8",
+            check=False,
         )
     except Exception:  # noqa: BLE001
         # jobstats unavailable or crashed entirely — leave rows unchanged.

--- a/src/reportseff/parameters.py
+++ b/src/reportseff/parameters.py
@@ -26,6 +26,7 @@ class ReportseffParameters:
     cluster: str = ""
     extra_args: str = ""
     array_min_size: int = 0  # Minimum size for job arrays to be reported
+    no_jobstats_fallback: bool = False
 
     def __post_init__(self) -> None:
         """Post init method to handle prepending format string with +."""

--- a/src/reportseff/parameters.py
+++ b/src/reportseff/parameters.py
@@ -26,7 +26,8 @@ class ReportseffParameters:
     cluster: str = ""
     extra_args: str = ""
     array_min_size: int = 0  # Minimum size for job arrays to be reported
-    no_jobstats_fallback: bool = False # Do not fallback to jobstats if AdminComment field is missing
+    # Do not fallback to jobstats if AdminComment field is missing
+    no_jobstats_fallback: bool = False
 
     def __post_init__(self) -> None:
         """Post init method to handle prepending format string with +."""

--- a/src/reportseff/parameters.py
+++ b/src/reportseff/parameters.py
@@ -26,7 +26,7 @@ class ReportseffParameters:
     cluster: str = ""
     extra_args: str = ""
     array_min_size: int = 0  # Minimum size for job arrays to be reported
-    no_jobstats_fallback: bool = False
+    no_jobstats_fallback: bool = False # Do not fallback to jobstats if AdminComment field is missing
 
     def __post_init__(self) -> None:
         """Post init method to handle prepending format string with +."""

--- a/tests/test_db_inquirer.py
+++ b/tests/test_db_inquirer.py
@@ -6,7 +6,12 @@ import subprocess
 import pytest
 from pytest_mock import MockerFixture
 
-from reportseff.db_inquirer import SacctInquirer
+import reportseff.db_inquirer as _dbi_mod
+from reportseff.db_inquirer import (
+    SacctInquirer,
+    _check_jobstats_available,
+    augment_with_jobstats,
+)
 
 STANDARD_ARGS = ["sacct", "--parsable", "-n", "--delimiter=^|^"]
 
@@ -894,3 +899,197 @@ def test_sacct_newline_jobs_issue_63(
     debug: list[str] = []
     sacct.get_db_output(["c1", "c2"], ["j1", "j2", "j3"], debug.append)
     assert debug[0] == ("c1 \\n j1^|^c2j1^|^\nc1j2^|^c2j2^|^\nc1j3^|^c2j3^|^\n")
+
+
+# ---------------------------------------------------------------------------
+# Tests for _check_jobstats_available
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=False)
+def reset_jobstats_cache():
+    """Reset the module-level availability cache before and after each test."""
+    _dbi_mod._JOBSTATS_AVAILABLE = None
+    yield
+    _dbi_mod._JOBSTATS_AVAILABLE = None
+
+
+def test_check_jobstats_not_on_path(mocker: MockerFixture, reset_jobstats_cache) -> None:
+    """Return False when jobstats is not found on PATH."""
+    mocker.patch("reportseff.db_inquirer.shutil.which", return_value=None)
+    assert _check_jobstats_available() is False
+
+
+def test_check_jobstats_found_with_base64_flag(
+    mocker: MockerFixture, reset_jobstats_cache
+) -> None:
+    """Return True when jobstats help text includes -b / --base64."""
+    mocker.patch("reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats")
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = "usage: jobstats [-h] [-j] [-b] [--base64] jobid\n"
+    mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=mock_result)
+    assert _check_jobstats_available() is True
+
+
+def test_check_jobstats_found_without_base64_flag(
+    mocker: MockerFixture, reset_jobstats_cache
+) -> None:
+    """Return False when jobstats exists but help text lacks -b / --base64."""
+    mocker.patch("reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats")
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = "usage: jobstats [-h] [-j] jobid\n"
+    mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=mock_result)
+    assert _check_jobstats_available() is False
+
+
+def test_check_jobstats_subprocess_exception(
+    mocker: MockerFixture, reset_jobstats_cache
+) -> None:
+    """Return False when the jobstats subprocess itself raises."""
+    mocker.patch("reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats")
+    mocker.patch(
+        "reportseff.db_inquirer.subprocess.run", side_effect=OSError("exec failed")
+    )
+    assert _check_jobstats_available() is False
+
+
+def test_check_jobstats_result_is_cached(
+    mocker: MockerFixture, reset_jobstats_cache
+) -> None:
+    """Availability check is cached; subprocess is only called once."""
+    mocker.patch("reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats")
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = "usage: jobstats [-b] jobid\n"
+    mock_sub = mocker.patch(
+        "reportseff.db_inquirer.subprocess.run", return_value=mock_result
+    )
+    _check_jobstats_available()
+    _check_jobstats_available()
+    # subprocess.run should only have been called once (for the -h check)
+    assert mock_sub.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests for augment_with_jobstats
+# ---------------------------------------------------------------------------
+
+def _make_row(
+    jobid: str,
+    jobidraw: str,
+    admin_comment: str = "",
+) -> dict:
+    return {"JobID": jobid, "JobIDRaw": jobidraw, "AdminComment": admin_comment}
+
+
+def test_augment_no_missing_rows(mocker: MockerFixture) -> None:
+    """Rows that already have AdminComment are not passed to jobstats."""
+    mock_sub = mocker.patch("reportseff.db_inquirer.subprocess.run")
+    rows = [_make_row("123", "123", "JS1:abc123def456ghi7")]
+    result = augment_with_jobstats(rows)
+    assert result[0]["AdminComment"] == "JS1:abc123def456ghi7"
+    mock_sub.assert_not_called()
+
+
+def test_augment_injects_valid_payload(mocker: MockerFixture) -> None:
+    """Valid base64 lines are prefixed with JS1: and injected."""
+    fake_b64 = "YWJjZGVmZ2hpamtsbW5vcA=="  # arbitrary valid base64
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = fake_b64 + "\n"
+    mock_result.returncode = 0
+    mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=mock_result)
+
+    rows = [_make_row("456", "456")]
+    result = augment_with_jobstats(rows)
+    assert result[0]["AdminComment"] == f"JS1:{fake_b64}"
+
+
+def test_augment_skips_none_sentinel(mocker: MockerFixture) -> None:
+    """Lines equal to 'None' (no Prometheus data) are silently skipped."""
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = "None\n"
+    mock_result.returncode = 0
+    mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=mock_result)
+
+    rows = [_make_row("789", "789")]
+    result = augment_with_jobstats(rows)
+    assert result[0]["AdminComment"] == ""
+
+
+def test_augment_skips_short_sentinel(mocker: MockerFixture) -> None:
+    """Lines equal to 'Short' (job too brief) are silently skipped."""
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = "Short\n"
+    mock_result.returncode = 0
+    mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=mock_result)
+
+    rows = [_make_row("321", "321")]
+    result = augment_with_jobstats(rows)
+    assert result[0]["AdminComment"] == ""
+
+
+def test_augment_partial_failure(mocker: MockerFixture) -> None:
+    """On partial failure only the rows matching stdout lines are updated."""
+    fake_b64 = "dGVzdHBheWxvYWQ="
+    mock_result = mocker.MagicMock()
+    # jobstats processed only the first ID before failing
+    mock_result.stdout = fake_b64 + "\n"
+    mock_result.returncode = 1
+    mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=mock_result)
+
+    rows = [_make_row("1", "1"), _make_row("2", "2")]
+    result = augment_with_jobstats(rows)
+    assert result[0]["AdminComment"] == f"JS1:{fake_b64}"
+    assert result[1]["AdminComment"] == ""  # not reached
+
+
+def test_augment_skips_substep_rows(mocker: MockerFixture) -> None:
+    """Rows with a '.' in JobID (.batch, .extern) are never sent to jobstats."""
+    mock_sub = mocker.patch("reportseff.db_inquirer.subprocess.run")
+    rows = [_make_row("123.batch", "123", "")]
+    augment_with_jobstats(rows)
+    mock_sub.assert_not_called()
+
+
+def test_augment_subprocess_exception(mocker: MockerFixture) -> None:
+    """If the subprocess itself raises, rows are returned unchanged."""
+    mocker.patch(
+        "reportseff.db_inquirer.subprocess.run", side_effect=OSError("exec failed")
+    )
+    rows = [_make_row("555", "555")]
+    result = augment_with_jobstats(rows)
+    assert result[0]["AdminComment"] == ""
+
+
+def test_augment_batch_array_job(mocker: MockerFixture) -> None:
+    """All array task rows are batched into a single subprocess call."""
+    b64_1 = "cGF5bG9hZDE="
+    b64_2 = "cGF5bG9hZDI="
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = f"{b64_1}\n{b64_2}\n"
+    mock_result.returncode = 0
+    mock_sub = mocker.patch(
+        "reportseff.db_inquirer.subprocess.run", return_value=mock_result
+    )
+
+    rows = [_make_row("100_1", "9001"), _make_row("100_2", "9002")]
+    result = augment_with_jobstats(rows)
+
+    assert result[0]["AdminComment"] == f"JS1:{b64_1}"
+    assert result[1]["AdminComment"] == f"JS1:{b64_2}"
+    # only one subprocess call with both raw IDs
+    assert mock_sub.call_count == 1
+    call_args = mock_sub.call_args[0][0]
+    assert "9001" in call_args
+    assert "9002" in call_args
+
+
+def test_augment_debug_message(mocker: MockerFixture) -> None:
+    """debug_cmd is called with an informational message when rows are missing."""
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = "None\n"
+    mock_result.returncode = 0
+    mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=mock_result)
+
+    debug_messages: list[str] = []
+    rows = [_make_row("42", "42")]
+    augment_with_jobstats(rows, debug_cmd=debug_messages.append)
+    assert any("jobstats fallback" in m for m in debug_messages)

--- a/tests/test_db_inquirer.py
+++ b/tests/test_db_inquirer.py
@@ -992,6 +992,18 @@ def _make_row(
     return {"JobID": jobid, "JobIDRaw": jobidraw, "AdminComment": admin_comment}
 
 
+def test_augment_jobstats_not_on_path(mocker: MockerFixture) -> None:
+    """Return rows unchanged when jobstats disappears before augmentation."""
+    mocker.patch("reportseff.db_inquirer.shutil.which", return_value=None)
+    mock_sub = mocker.patch("reportseff.db_inquirer.subprocess.run")
+    rows = [_make_row("654", "654")]
+
+    result = augment_with_jobstats(rows)
+
+    assert result == rows
+    mock_sub.assert_not_called()
+
+
 @pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_no_missing_rows(mocker: MockerFixture) -> None:
     """Rows that already have AdminComment are not passed to jobstats."""

--- a/tests/test_db_inquirer.py
+++ b/tests/test_db_inquirer.py
@@ -2,6 +2,7 @@
 
 import datetime
 import subprocess
+from collections.abc import Generator
 
 import pytest
 from pytest_mock import MockerFixture
@@ -906,7 +907,7 @@ def test_sacct_newline_jobs_issue_63(
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(autouse=False)
-def reset_jobstats_cache():
+def reset_jobstats_cache() -> Generator[None, None, None]:
     """Reset the module-level availability cache before and after each test."""
     _dbi_mod._JOBSTATS_AVAILABLE = None
     yield
@@ -988,7 +989,7 @@ def _make_row(
     jobid: str,
     jobidraw: str,
     admin_comment: str = "",
-) -> dict:
+) -> dict[str, str]:
     return {"JobID": jobid, "JobIDRaw": jobidraw, "AdminComment": admin_comment}
 
 

--- a/tests/test_db_inquirer.py
+++ b/tests/test_db_inquirer.py
@@ -913,50 +913,55 @@ def reset_jobstats_cache():
     _dbi_mod._JOBSTATS_AVAILABLE = None
 
 
-def test_check_jobstats_not_on_path(mocker: MockerFixture, reset_jobstats_cache) -> None:
+@pytest.mark.usefixtures("reset_jobstats_cache")
+def test_check_jobstats_not_on_path(mocker: MockerFixture) -> None:
     """Return False when jobstats is not found on PATH."""
     mocker.patch("reportseff.db_inquirer.shutil.which", return_value=None)
     assert _check_jobstats_available() is False
 
 
-def test_check_jobstats_found_with_base64_flag(
-    mocker: MockerFixture, reset_jobstats_cache
-) -> None:
+@pytest.mark.usefixtures("reset_jobstats_cache")
+def test_check_jobstats_found_with_base64_flag(mocker: MockerFixture) -> None:
     """Return True when jobstats help text includes -b / --base64."""
-    mocker.patch("reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats")
+    mocker.patch(
+        "reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats"
+    )
     mock_result = mocker.MagicMock()
     mock_result.stdout = "usage: jobstats [-h] [-j] [-b] [--base64] jobid\n"
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=mock_result)
     assert _check_jobstats_available() is True
 
 
-def test_check_jobstats_found_without_base64_flag(
-    mocker: MockerFixture, reset_jobstats_cache
-) -> None:
+@pytest.mark.usefixtures("reset_jobstats_cache")
+def test_check_jobstats_found_without_base64_flag(mocker: MockerFixture) -> None:
     """Return False when jobstats exists but help text lacks -b / --base64."""
-    mocker.patch("reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats")
+    mocker.patch(
+        "reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats"
+    )
     mock_result = mocker.MagicMock()
     mock_result.stdout = "usage: jobstats [-h] [-j] jobid\n"
     mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=mock_result)
     assert _check_jobstats_available() is False
 
 
-def test_check_jobstats_subprocess_exception(
-    mocker: MockerFixture, reset_jobstats_cache
-) -> None:
+@pytest.mark.usefixtures("reset_jobstats_cache")
+def test_check_jobstats_subprocess_exception(mocker: MockerFixture) -> None:
     """Return False when the jobstats subprocess itself raises."""
-    mocker.patch("reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats")
+    mocker.patch(
+        "reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats"
+    )
     mocker.patch(
         "reportseff.db_inquirer.subprocess.run", side_effect=OSError("exec failed")
     )
     assert _check_jobstats_available() is False
 
 
-def test_check_jobstats_result_is_cached(
-    mocker: MockerFixture, reset_jobstats_cache
-) -> None:
+@pytest.mark.usefixtures("reset_jobstats_cache")
+def test_check_jobstats_result_is_cached(mocker: MockerFixture) -> None:
     """Availability check is cached; subprocess is only called once."""
-    mocker.patch("reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats")
+    mocker.patch(
+        "reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats"
+    )
     mock_result = mocker.MagicMock()
     mock_result.stdout = "usage: jobstats [-b] jobid\n"
     mock_sub = mocker.patch(
@@ -972,6 +977,13 @@ def test_check_jobstats_result_is_cached(
 # Tests for augment_with_jobstats
 # ---------------------------------------------------------------------------
 
+@pytest.fixture
+def _mock_jobstats_path(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "reportseff.db_inquirer.shutil.which", return_value="/usr/bin/jobstats"
+    )
+
+
 def _make_row(
     jobid: str,
     jobidraw: str,
@@ -980,6 +992,7 @@ def _make_row(
     return {"JobID": jobid, "JobIDRaw": jobidraw, "AdminComment": admin_comment}
 
 
+@pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_no_missing_rows(mocker: MockerFixture) -> None:
     """Rows that already have AdminComment are not passed to jobstats."""
     mock_sub = mocker.patch("reportseff.db_inquirer.subprocess.run")
@@ -989,6 +1002,7 @@ def test_augment_no_missing_rows(mocker: MockerFixture) -> None:
     mock_sub.assert_not_called()
 
 
+@pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_injects_valid_payload(mocker: MockerFixture) -> None:
     """Valid base64 lines are prefixed with JS1: and injected."""
     fake_b64 = "YWJjZGVmZ2hpamtsbW5vcA=="  # arbitrary valid base64
@@ -1002,6 +1016,7 @@ def test_augment_injects_valid_payload(mocker: MockerFixture) -> None:
     assert result[0]["AdminComment"] == f"JS1:{fake_b64}"
 
 
+@pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_skips_none_sentinel(mocker: MockerFixture) -> None:
     """Lines equal to 'None' (no Prometheus data) are silently skipped."""
     mock_result = mocker.MagicMock()
@@ -1014,6 +1029,7 @@ def test_augment_skips_none_sentinel(mocker: MockerFixture) -> None:
     assert result[0]["AdminComment"] == ""
 
 
+@pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_skips_short_sentinel(mocker: MockerFixture) -> None:
     """Lines equal to 'Short' (job too brief) are silently skipped."""
     mock_result = mocker.MagicMock()
@@ -1026,6 +1042,7 @@ def test_augment_skips_short_sentinel(mocker: MockerFixture) -> None:
     assert result[0]["AdminComment"] == ""
 
 
+@pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_partial_failure(mocker: MockerFixture) -> None:
     """On partial failure only the rows matching stdout lines are updated."""
     fake_b64 = "dGVzdHBheWxvYWQ="
@@ -1041,6 +1058,7 @@ def test_augment_partial_failure(mocker: MockerFixture) -> None:
     assert result[1]["AdminComment"] == ""  # not reached
 
 
+@pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_skips_substep_rows(mocker: MockerFixture) -> None:
     """Rows with a '.' in JobID (.batch, .extern) are never sent to jobstats."""
     mock_sub = mocker.patch("reportseff.db_inquirer.subprocess.run")
@@ -1049,6 +1067,7 @@ def test_augment_skips_substep_rows(mocker: MockerFixture) -> None:
     mock_sub.assert_not_called()
 
 
+@pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_subprocess_exception(mocker: MockerFixture) -> None:
     """If the subprocess itself raises, rows are returned unchanged."""
     mocker.patch(
@@ -1059,6 +1078,7 @@ def test_augment_subprocess_exception(mocker: MockerFixture) -> None:
     assert result[0]["AdminComment"] == ""
 
 
+@pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_batch_array_job(mocker: MockerFixture) -> None:
     """All array task rows are batched into a single subprocess call."""
     b64_1 = "cGF5bG9hZDE="
@@ -1082,6 +1102,7 @@ def test_augment_batch_array_job(mocker: MockerFixture) -> None:
     assert "9002" in call_args
 
 
+@pytest.mark.usefixtures("_mock_jobstats_path")
 def test_augment_debug_message(mocker: MockerFixture) -> None:
     """debug_cmd is called with an informational message when rows are missing."""
     mock_result = mocker.MagicMock()

--- a/tests/test_reportseff.py
+++ b/tests/test_reportseff.py
@@ -138,6 +138,7 @@ def test_debug_option(mocker: MockerFixture, console_jobs: dict[str, str]) -> No
 def test_jobstats_fallback_wiring(
     mocker: MockerFixture,
     console_jobs: dict[str, str],
+    *,
     debug: bool,
 ) -> None:
     """Pass the expected debug callback to the jobstats fallback."""

--- a/tests/test_reportseff.py
+++ b/tests/test_reportseff.py
@@ -133,6 +133,45 @@ def test_debug_option(mocker: MockerFixture, console_jobs: dict[str, str]) -> No
     ]
 
 
+@pytest.mark.parametrize("debug", [False, True])
+@pytest.mark.usefixtures("_mock_inquirer")
+def test_jobstats_fallback_wiring(
+    mocker: MockerFixture,
+    console_jobs: dict[str, str],
+    debug: bool,
+) -> None:
+    """Pass the expected debug callback to the jobstats fallback."""
+    mocker.patch("reportseff.console.which", return_value=True)
+    mocker.patch("reportseff.console._check_jobstats_available", return_value=True)
+    runner = CliRunner()
+    sub_result = mocker.MagicMock()
+    sub_result.returncode = 0
+    sub_result.stdout = console_jobs["23000233"]
+    mocker.patch("reportseff.db_inquirer.subprocess.run", return_value=sub_result)
+
+    def augment(rows: list[dict[str, str]], *, debug_cmd: Any) -> list[dict[str, str]]:
+        if debug_cmd is not None:
+            debug_cmd("jobstats fallback invoked")
+        return rows
+
+    mock_augment = mocker.patch(
+        "reportseff.console.augment_with_jobstats", side_effect=augment
+    )
+    arguments = ["--no-color", "23000233"]
+    if debug:
+        arguments.insert(1, "--debug")
+
+    result = runner.invoke(console.main, arguments)
+
+    assert result.exit_code == 0
+    mock_augment.assert_called_once()
+    assert mock_augment.call_args.kwargs["debug_cmd"] is not None if debug else (
+        mock_augment.call_args.kwargs["debug_cmd"] is None
+    )
+    if debug:
+        assert "jobstats fallback invoked" in result.output
+
+
 @pytest.mark.usefixtures("_mock_inquirer")
 def test_process_failure(mocker: MockerFixture, console_jobs: dict[str, str]) -> None:
     """Catch exceptions in process_entry by printing the offending entry."""

--- a/uv.lock
+++ b/uv.lock
@@ -19,14 +19,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -875,7 +875,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "click", specifier = ">=6.7" }]
+requires-dist = [{ name = "click", specifier = ">=6.7,!=8.3.0,!=8.3.1,!=8.3.2" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This feature fixes a silent break that occurs in the more recent versions of  `jobstats`.  Originally,  `reportseff` uses the `AdminComment` field in `sacct` to obtain the job's GPU performance metrics (**GpuEff**, **GpuMemEff**).  But that field has been removed in favor of using an external database.  The `jobstats` project already provides a fix which involves mirroring that information in slurm's db `AdminComment` field. I'm also the one who proposed that fix.

In some `jobstats` cluster deployments, the cluster admin might decide not to apply the fix. In those cases this pull request is providing a *last resort* fallback, to obtain the GPU metrics using `jobstats` public API instead.  I've first got the idea for this workaround from a developer's comment on the `jobstats` [issue discussion](https://github.com/PrincetonUniversity/jobstats/pull/55), where the silent break was highlighted.

It's important to stress that the `AdminComment` mirror **is** in my opinion and from a *reportseff* user's egoistic perspective, the preferred and faster fix.  In any case, **reportseff** users can decide to disable the fallback by passing a command line option to avoid the additional time penalty.

I've used a Coding Agent website (claude.ai/Sonnet 4.6) to engineer and implement this feature. 